### PR TITLE
French translation for new variables

### DIFF
--- a/src/main/java/Bundle.properties
+++ b/src/main/java/Bundle.properties
@@ -50,9 +50,9 @@ yes=Yes
 no=No
 previous=Previous
 next=Next
-more=More...
-less=Less...
-select=Select...
+more=More\u2026
+less=Less\u2026
+select=Select\u2026
 selectedFiles=Selected Files
 htmlAllowedTitle=Allowed HTML Tags
 htmlAllowedMsg=This field supports only certain <span class="text-info popoverHTML">HTML tags</span>.
@@ -61,7 +61,7 @@ htmlAllowedTags=<a>, <b>, <blockquote>, <br>, <code>, <del>, <dd>, <dl>, <dt>, <
 # dataverse_header.xhtml
 
 header.status.header=Status
-header.search.title=Search all dataverses...
+header.search.title=Search all dataverses\u2026
 header.about=About
 header.support=Support
 header.guides=Guides
@@ -119,7 +119,7 @@ contact.from.required=User email is required.
 contact.from.invalid=Email is invalid.
 contact.subject=Subject
 contact.subject.required=Subject is required.
-contact.subject.selectTab.top=Select subject...
+contact.subject.selectTab.top=Select subject\u2026
 contact.subject.selectTab.support=Support Question
 contact.subject.selectTab.dataIssue=Data Issue
 contact.msg=Message
@@ -372,7 +372,7 @@ harvestclients.newClientDialog.type.Nesstar=Nesstar
 
 harvestclients.newClientDialog.url=Server URL
 harvestclients.newClientDialog.url.tip=URL of a harvesting resource.
-harvestclients.newClientDialog.url.watermark=Remote harvesting server, http://...
+harvestclients.newClientDialog.url.watermark=Remote harvesting server, http://\u2026
 harvestclients.newClientDialog.url.helptext.notvalidated=URL of a harvesting resource. Once you click 'Next', we will try to establish a connection to the server in order to verify that it is working, and to obtain extra information about its capabilities. 
 harvestclients.newClientDialog.url.required=A valid harvesting server address is required.
 harvestclients.newClientDialog.url.invalid=Invalid URL. Failed to establish connection and receive a valid server response. 
@@ -558,14 +558,14 @@ passwdReset.resetBtn=Reset Password
 # dataverse.xhtml
 
 dataverse.title=The project, department, university, or professor this dataverse will contain data for.
-dataverse.enterName=Enter name...
+dataverse.enterName=Enter name\u2026
 dataverse.host.title=The dataverse which contains this data.
 dataverse.identifier.title=Short name used for the URL of this dataverse.
 dataverse.affiliation.title=The organization with which this dataverse is affiliated.
 
 dataverse.category=Category
 dataverse.category.title=The type that most closely reflects this dataverse.
-dataverse.type.selectTab.top=Select one...
+dataverse.type.selectTab.top=Select one\u2026
 dataverse.type.selectTab.researchers=Researcher
 dataverse.type.selectTab.researchProjects=Research Project
 dataverse.type.selectTab.journals=Journal
@@ -680,8 +680,8 @@ advanced.search.files.variableLabel.tip=A short description of the variable.
 # search-include-fragment.xhtml
 
 dataverse.search.advancedSearch=Advanced Search
-dataverse.search.input.watermark=Search this dataverse...
-account.search.input.watermark=Search this data...
+dataverse.search.input.watermark=Search this dataverse\u2026
+account.search.input.watermark=Search this data\u2026
 dataverse.search.btn.find=Find
 
 dataverse.results.btn.addData=Add Data
@@ -766,7 +766,7 @@ dataverse.theme.tagline.title=A phrase or sentence that describes this dataverse
 dataverse.theme.tagline.tip=Provide a tagline that is 140 characters or less. 
 dataverse.theme.website.title=URL for your personal website, institution, or any website that relates to this dataverse.
 dataverse.theme.website.tip=The website will be linked behind the tagline. To have a website listed, you must also provide a tagline. 
-dataverse.theme.website.watermark=Your personal site, http://...
+dataverse.theme.website.watermark=Your personal site, http://\u2026
 dataverse.theme.website.invalidMsg=Invalid URL.
 
 dataverse.widgets.title=Widgets
@@ -1093,7 +1093,7 @@ dataset.exportBtn.itemLabel.dublinCore=Dublin Core
 dataset.exportBtn.itemLabel.json=JSON
 metrics.title=Metrics
 metrics.title.tip=View more metrics information
-metrics.comingsoon=Coming soon...
+metrics.comingsoon=Coming soon\u2026
 metrics.views=Views
 metrics.downloads={0, choice, 0#Downloads|1#Download|2#Downloads}
 metrics.citations=Citations
@@ -1256,7 +1256,7 @@ file.selectedThumbnail.tip=The thumbnail for this file is used as the default th
 file.metaData.dataFile.dataTab.variables=Variables
 file.metaData.dataFile.dataTab.observations=Observations
 file.metaData.viewOnWorldMap=Explore on WorldMap
-file.addDescription=Add file description...
+file.addDescription=Add file description\u2026
 file.tags=Tags
 file.editTags=Edit Tags
 file.editTagsDialog.tip=Select existing file tags or create new tags to describe your files. Each file can have more than one tag.
@@ -1265,7 +1265,7 @@ file.editTagsDialog.selectedTags=Selected Tags
 file.editTagsDialog.selectedTags.none=No tags selected
 file.editTagsDialog.add=Custom File Tag
 file.editTagsDialog.add.tip=Creating a new tag will add it as a tag option for all files in this dataset.
-file.editTagsDialog.newName=Add new file tag...
+file.editTagsDialog.newName=Add new file tag\u2026
 dataset.removeUnusedFileTags.label=Delete Tags
 dataset.removeUnusedFileTags.tip=Select to delete Custom File Tags not used by the files in the dataset.
 dataset.removeUnusedFileTags.check=Delete tags not being used
@@ -1306,7 +1306,7 @@ file.requestAccess.dialog.msg=You need to <a href="/loginpage.xhtml{0}" target="
 file.requestAccess.dialog.msg.signup=You need to <a href="/dataverseuser.xhtml{0}&amp;editMode=CREATE" target="{1}" title="Sign Up for a Dataverse Account">Sign Up</a> or <a href="/loginpage.xhtml{0}" target="{1}" title="Log into your Dataverse Account">Log In</a> to request access to this file.
 file.accessRequested=Access Requested
 
-file.ingestInProgress=Ingest in progress...
+file.ingestInProgress=Ingest in progress\u2026
 
 file.dataFilesTab.metadata.header=Metadata
 file.dataFilesTab.metadata.addBtn=Add + Edit Metadata
@@ -1420,7 +1420,7 @@ file.deaccessionDialog.reason.selectItem.notValid=Not a valid dataset
 file.deaccessionDialog.reason.selectItem.other=Other (Please type reason in space provided below)
 file.deaccessionDialog.enterInfo=Please enter additional information about the reason for deaccession.
 file.deaccessionDialog.leaveURL=If applicable, please leave a URL where this dataset can be accessed after deaccessioning.
-file.deaccessionDialog.leaveURL.watermark=Optional dataset site, http://...
+file.deaccessionDialog.leaveURL.watermark=Optional dataset site, http://\u2026
 file.deaccessionDialog.deaccession.tip=Are you sure you want to deaccession? The selected version(s) will no longer be viewable by the public.
 file.deaccessionDialog.deaccessionDataset.tip=Are you sure you want to deaccession this dataset? It will no longer be viewable by the public.
 file.deaccessionDialog.dialog.selectVersion.tip=Please select version(s) for deaccessioning.
@@ -1454,7 +1454,7 @@ file.downloadDialog.header=Download File
 file.downloadDialog.tip=Please confirm and/or complete the information needed below in order to download files in this dataset.
 file.downloadDialog.termsTip=I accept these Terms of Use.
 
-file.search.placeholder=Search these data files...
+file.search.placeholder=Search these data files\u2026
 file.results.btn.sort=Sort
 file.results.btn.sort.option.nameAZ=Name (A-Z)
 file.results.btn.sort.option.nameZA=Name (Z-A)
@@ -1512,7 +1512,7 @@ file.metadataTab.fileMetadata.publicationDate.label=Publication Date
 file.metadataTab.fileMetadata.depositDate.label=Deposit Date
 file.metadataTab.fitsMetadata.header=FITS Metadata
 file.metadataTab.provenance.header=File Provenance
-file.metadataTab.provenance.body=File Provenance information coming in a later release...
+file.metadataTab.provenance.body=File Provenance information coming in a later release\u2026
 
 file.versionDifferences.noChanges=No changes associated with this version
 file.versionDifferences.fileNotInVersion=File not included in this version
@@ -1612,7 +1612,7 @@ dta.datasettimestamp.error=unexpected/invalid length of the time stamp in the DT
 dta.variabletype.label.error=Unrecognized type label: {0} for Stata type value (short) {1}.
 dta.variabletype.value.error=unknown variable type value encountered: {0}
 dta.vartype.error=Undefined variable type encountered in readData()
-dta.datasection.error=unknown variable type encounted when reading data section: {0}
+dta.datasection.error=unknown variable type encountered when reading data section: {0}
 dta.byteoffset.error=Unexpected number of bytes read for data row {0}; {1} expected, {2} read.
 dta.readSTRLs.failure=Failed to read an intermediate v,o Pair for variable {0}, observation {1}
 dta.readSTRLs.illegal=Illegal v,o value: {0} for variable {1}, observation {2}
@@ -1858,7 +1858,7 @@ mydataFragment.moreResults=View More Results
 mydataFragment.publicacionStatus=Publication Status
 mydataFragment.roles=Roles
 mydataFragment.resultsByUserName=Results by Username
-mydataFragment.search=Search my data...
+mydataFragment.search=Search my data\u0026
 
 Published=Published
 Unpublished=Unpublished

--- a/src/main/java/Bundle_fr.properties
+++ b/src/main/java/Bundle_fr.properties
@@ -93,7 +93,7 @@ footer.dataverseProjectOn=Projet Dataverse sur
 footer.Twitter=Twitter
 footer.dataScienceIQSS=Développé au <a href="http://www.iq.harvard.edu/" title="Institute for Quantitative Social Science" target="_blank">Institute for Quantitative Social Science</a>
 footer.copyright=Droits réservés &#169; {0}
-footer.widget.datastored=Les données sont archivées par: {0}.
+footer.widget.datastored=Les données sont archivées par\u00A0: {0}.
 footer.widget.login=Se connecter à
 footer.privacyPolicy=Politique de protection de la vie privée
 footer.poweredby=Fourni par
@@ -101,11 +101,11 @@ footer.dataverseProject=Le projet Dataverse
 
 # messages.xhtml
 
-messages.error=Error
-messages.success=Success!
+messages.error=Erreur
+messages.success=Opération réussie!
 messages.info=Info
-messages.validation=Validation Error
-messages.validation.msg=Required fields were missed or there was a validation error. Please scroll down to see details.
+messages.validation=Erreur de validation
+messages.validation.msg=Des champs requis sont manquants ou encore une erreur de validation est survenue. Faites défiler vers le bas pour voir les détails.
 
 # contactFormFragment.xhtml=
 
@@ -113,7 +113,7 @@ contact.header=Communiquer avec le service de soutien Scholars Portal
 contact.dataverse.header=Communiquer avec la personne-ressource pour ce dataverse
 contact.dataset.header=Communiquer avec la personne-ressource pour cet ensemble de données
 contact.to=Destinataire
-contact.support=Service de soutien Scholars Portal
+contact.support=Service de soutien de Scholars Portal
 contact.from=Expéditeur
 contact.from.required=L'adresse courriel de l'utilisateur est requise.
 contact.from.invalid=L'adresse courriel est invalide.
@@ -139,8 +139,8 @@ apiTaken=Jeton API
 user.isShibUser=Les renseignements sur le compte ne peuvent être modifiés lorsque connecté via un compte institutionnel.
 user.helpShibUserMigrateOffShibBeforeLink=Vous quittez votre établissement? Prière de contacter
 user.helpShibUserMigrateOffShibAfterLink=pour obtenir de l'aide.
-user.helpOAuthBeforeLink=Your Dataverse account uses {0} for login. If you are interested in changing login methods, please contact
-user.helpOAuthAfterLink=for assistance.
+user.helpOAuthBeforeLink=Votre compte Dataverse utilise {0} pour pouvoir se connecter. Si vous souhaitez modifier vos modes de connexion, prière de contacter
+user.helpOAuthAfterLink=pour obtenir du soutien.
 user.lostPasswdTip=Si vous avez perdu ou oublié votre mot de passe, indiquez votre nom d'utilisateur ou votre adresse courriel dans l'espace ci-dessous et cliquez sur «\u00A0Soumettre\u00A0». Nous vous enverrons votre nouveau mot de passe par courriel.
 user.dataRelatedToMe=Mes données
 wasCreatedIn=a été créé dans
@@ -151,11 +151,11 @@ wasReturnedByReviewer=a été retourné par l'intendant des données de
 toReview=N'oubliez pas de les publier ou de les renvoyer au collaborateur!
 worldMap.added=Les données d'une couche WorldMap ont été ajoutées à l'ensemble de données.
 # Bundle file editors, please note that "notification.welcome" is used in a unit test.=
-notification.welcome=Bienvenue dans le Dataverse de {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le: {1}. Vous voulez faire l'essai des composantes de Dataverse? Essayez notre {2}.  N'oubliez pas de vérifier que vous avez bien reçu votre courriel d'invitation afin que nous puissions valider votre adresse.
+notification.welcome=Bienvenue dans le Dataverse de {0}! Commencez dès maintenant en ajoutant ou encore en recherchant des données. Des questions? Consultez le\u00A0: {1}. Vous voulez faire l'essai des composantes de Dataverse? Essayez notre {2}.  N'oubliez pas de vérifier que vous avez bien reçu votre courriel d'invitation afin que nous puissions valider votre adresse.
 notification.demoSite=Site de démonstration
-notification.requestFileAccess=Demande d'accès pour l'ensemble de données: {0}.
-notification.grantFileAccess=Accès accordé pour les fichiers de l'ensemble de données:  {0}.
-notification.rejectFileAccess=Demande d'accès refusée pour les fichiers de l'ensemble de données:  {0}.
+notification.requestFileAccess=Demande d'accès pour l'ensemble de données\u00A0: {0}.
+notification.grantFileAccess=Accès accordé pour les fichiers de l'ensemble de données\u00A0: {0}.
+notification.rejectFileAccess=Demande d'accès refusée pour les fichiers de l'ensemble de données\u00A0: {0}.
 notification.createDataverse={0}  a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre dataverse, consultez le {2}.
 notification.dataverse.management.title=Administration de Dataverse - Guide d'utilisation Dataverse
 notification.createDataset={0}  a été créé dans {1}. Pour savoir ce que vous pouvez faire avec votre ensemble de données, consultez le {2}.
@@ -173,13 +173,13 @@ notification.access.granted.fileDownloader.additionalDataset={0} Vous avez maint
 notification.access.revoked.dataverse=Votre rôle dans {0} a été retiré.
 notification.access.revoked.dataset=Votre rôle dans {0} a été retiré.
 notification.access.revoked.datafile=Votre rôle dans {0} a été retiré.
-notification.checksumfail=Your upload to dataset "{0}" failed checksum validation.
-notification.import.filesystem=<a href="{0}/dataset.xhtml?persistentId={1}" title="{2}"&>{2}</a>, dataset had files imported from the file system via a batch job.
-notification.import.checksum=<a href="/dataset.xhtml?persistentId={0}" title="{1}"&>{1}</a>, dataset had file checksums added via a batch job.
+notification.checksumfail=Votre téléchargement dans l'ensemble de données "{0}" a échoué la validation de la somme de contrôle.
+notification.import.filesystem=<a href="{0}/dataset.xhtml?persistentId={1}" title="{2}"&>{2}</a>, l'ensemble de données a importé des fichiers à partir du système de fichiers par l'entremise d'un traitement en lot.
+notification.import.checksum=<a href="/dataset.xhtml?persistentId={0}" title="{1}"&>{1}</a>, l'ensemble de données a ajouté les sommes de contôle des fichiers par l'entremise d'un traitement en lot.
 removeNotification=Supprimer l'avis
 groupAndRoles.manageTips=Vous pouvez gérer tous les groupes dont vous êtes membre et les rôles qui vous ont été confiés et y avoir accès.
 user.signup.tip=Pourquoi se créer un compte Dataverse? De façon à pouvoir créer votre propre dataverse, le personnaliser, y ajouter des ensembles de données, ou encore pour demander l'accès à des fichiers à accès réservé. 
-user.signup.otherLogInOptions.tip= <a href="/loginpage.xhtml" title="Dataverse Log In">See other log in options.</a>
+user.signup.otherLogInOptions.tip= <a href="/loginpage.xhtml" title="Dataverse - Se connecter">Voir les autres options de connexion.</a>
 user.username.illegal.tip=Votre nom d'utilisateur doit compter entre 2 et 60\u00A0caractères et vous pouvez utiliser les lettres a à z, les chiffres 0 à 9 et le caractère souligné «\u00A0_\u00A0».
 user.username=Nom d'utilisateur
 user.username.taken=Ce nom d'utilisateur est déjà pris.
@@ -197,7 +197,7 @@ user.email.tip=Une adresse courriel valide permettant de communiquer avec vous.
 user.email.taken=Cette adresse courriel est déjà prise.
 user.affiliation.tip=L'organisation avec laquelle vous êtes affilié(e).
 user.position=Poste
-user.position.tip=Votre rôle ou titre au sein de l'organisation avec laquelle vous êtes affilié(e), par exemple : employé(e), membre du corps professoral, étudiant(e), etc. 
+user.position.tip=Votre rôle ou titre au sein de l'organisation avec laquelle vous êtes affilié(e), par exemple\u00A0: employé(e), membre du corps professoral, étudiant(e), etc. 
 user.acccountterms=Conditions générales d'utilisation
 user.acccountterms.tip=Les conditions d'utilisation de l'application et des services.
 user.acccountterms.required=Veuillez cocher la case pour indiquer que vous acceptez les conditions générales d'utilisation.
@@ -214,7 +214,7 @@ login.System=Système d'authentification
 login.forgot.text=Mot de passe oublié?
 login.builtin=Compte Dataverse
 login.institution=Compte institutionnel
-login.institution.blurb=Log in or sign up with your institutional account &mdash; <a href="{0}/{1}/user/account.html" target="_blank">learn more</a>.
+login.institution.blurb=Connectez-vous ou inscrivez-vous avec votre compte institutionnel &mdash; <a href="{0}/{1}/user/account.html" target="_blank">en apprendre davantage</a>.
 login.institution.support.beforeLink=Vous quittez votre établissement? Prière de contacter
 login.institution.support.afterLink=pour obtenir de l'aide.
 login.builtin.credential.usernameOrEmail=Nom d'utilisateur/courriel
@@ -222,22 +222,22 @@ login.builtin.credential.password=Mot de passe
 login.builtin.invalidUsernameEmailOrPassword=Le nom d'utilisateur, le courriel ou le mot de passe indiqué n'est pas valide. Avez-vous besoin d'aide pour accéder à votre compte?
 # how do we exercise login.error? Via a password upgrade failure? See https://github.com/IQSS/dataverse/pull/2922=
 login.error=Une erreur s'est produite au moment de la validation du nom d'utilisateur ou du mot de passe. Veuillez essayer à nouveau. Si le problème persiste, communiquez avec un administrateur.
-user.error.cannotChangePassword=Sorry, your password cannot be changed. Please contact your system administrator.
-user.error.wrongPassword=Sorry, wrong password.
-login.button=Log In with {0}
+user.error.cannotChangePassword=Désolé, votre mot de passe ne peut pas être modifié. Veuillez contacter votre administrateur système.
+user.error.wrongPassword=Désolé, mot de passe erronné.
+login.button=Connectez-vous avec {0}
 # authentication providers
-auth.providers.title=Other options
-auth.providers.tip=You can convert a Dataverse account to use one of the options above. <a href="{0}/{1}/user/account.html" target="_blank">Learn more</a>.
-auth.providers.title.builtin=Username/Email
-auth.providers.title.shib=Your Institution
+auth.providers.title=Autres options
+auth.providers.tip=Vous pouvez convertir un compte Dataverse pour utiliser l'une des options ci-dessus. <a href="{0}/{1}/user/account.html" target="_blank">En apprendre davantage</a>.
+auth.providers.title.builtin=Nom d'utilisateur/Courriel
+auth.providers.title.shib=Votre établissement
 auth.providers.title.orcid=ORCID
 auth.providers.title.google=Google
 auth.providers.title.github=GitHub
-auth.providers.blurb=Log in or sign up with your {0} account &mdash; <a href="{1}/{2}/user/account.html" target="_blank">learn more</a>. Having trouble? Please contact {3} for assistance.
-auth.providers.persistentUserIdName.orcid=ORCID iD
-auth.providers.persistentUserIdName.github=ID
-auth.providers.persistentUserIdTooltip.orcid=ORCID provides a persistent digital identifier that distinguishes you from other researchers.
-auth.providers.persistentUserIdTooltip.github=GitHub assigns a unique number to every user.
+auth.providers.blurb=Connectez-vous ou inscrivez-vous avec votre compte {0} &mdash; <a href="{1}/{2}/user/account.html" target="_blank">en apprendre davantage</a>. Vous éprouvez des problèmes? Veuillez contacter {3} pour obtenir de l'aide.
+auth.providers.persistentUserIdName.orcid=Identifiant ORCID
+auth.providers.persistentUserIdName.github=Identifiant GitHub
+auth.providers.persistentUserIdTooltip.orcid=ORCID fournit un identifiant numérique pérenne qui vous distingue des autres chercheurs.
+auth.providers.persistentUserIdTooltip.github=GitHub attribue un identifiant unique à chaque utilisateur.
 
 #confirmemail.xhtml=
 confirmEmail.pageTitle=Validation du courriel
@@ -264,45 +264,45 @@ shib.offerToCreateNewAccount=Cette information est fournie par votre établisseme
 shib.passwordRejected=<strong>Erreur de validation</strong> - Votre compte peut uniquement être converti si vous indiquez le bon mot de passe pour votre compte existant.
 
 # oauth2/firstLogin.xhtml
-oauth2.btn.convertAccount=Convert Existing Account
-oauth2.btn.createAccount=Create New Account
-oauth2.askToConvert=Would you like to convert your Dataverse account to always use your institutional log in?
-oauth2.welcomeExistingUserMessage=Your institutional log in for {0} matches an email address already being used for a Dataverse account. By entering your current Dataverse password below, your existing Dataverse account can be converted to use your institutional log in. After converting, you will only need to use your institutional log in.
-oauth2.welcomeExistingUserMessageDefaultInstitution=your institution
-oauth2.dataverseUsername=Dataverse Username
-oauth2.currentDataversePassword=Current Dataverse Password
-oauth2.chooseUsername=Username: 
-oauth2.passwordRejected=<strong>Validation Error</strong> - Wrong username or password.
-# oauth2.newAccount.title=Account Creation
-oauth2.newAccount.welcomeWithName=Welcome to Dataverse, {0}
-oauth2.newAccount.welcomeNoName=Welcome to Dataverse
-# oauth2.newAccount.email=Email
-# oauth2.newAccount.email.tip=Dataverse uses this email to notify you of issues regarding your data.
-oauth2.newAccount.suggestedEmails=Suggested Email Addresses:
-oauth2.newAccount.username=Username
-oauth2.newAccount.username.tip=This username will be your unique identifier as a Dataverse user.
-oauth2.newAccount.explanation=This information is provided by {0} and will be used to create your {1} account. To log in again, you will have to use the {0} log in option.
-oauth2.newAccount.suggestConvertInsteadOfCreate=If you already have a {0} account, you will need to <a href="/oauth2/convert.xhtml">convert your account.</a>
-# oauth2.newAccount.tabs.convertAccount=Convert Existing Account
-oauth2.newAccount.buttons.convertNewAccount=Convert Account
-oauth2.newAccount.emailTaken=Email already taken. Consider merging the corresponding account instead.
-oauth2.newAccount.emailOk=Email OK.
-oauth2.newAccount.emailInvalid=Invalid email address.
-# oauth2.newAccount.usernameTaken=Username already taken.
-# oauth2.newAccount.usernameOk=Username OK.
+oauth2.btn.convertAccount=Convertir le compte existant
+oauth2.btn.createAccount=Créer un nouveau compte
+oauth2.askToConvert=Désirez-vous convertir votre compte Dataverse de façon à toujours utiliser votre compte institutionnel? 
+oauth2.welcomeExistingUserMessage=Votre compte institutionnel {0} correspond à une adresse courriel déjà utilisée pour un compte Dataverse. En entrant votre mot de passe actuel de Dataverse ci-dessous, votre compte Dataverse existant peut être converti pour utiliser votre compte institutionnel à la place. Suite à la conversion vous n'aurez plus qu'à utiliser votre compte institutionnel.
+oauth2.welcomeExistingUserMessageDefaultInstitution=votre établissement
+oauth2.dataverseUsername=Nom d'utilisateur Dataverse
+oauth2.currentDataversePassword=Mot de passe Dataverse actuel
+oauth2.chooseUsername=Nom d'utilisateur\u00A0: 
+oauth2.passwordRejected=<strong>Erreur de validation</strong> - Nom d'utilisateur ou mot de passe incorrect.
+# oauth2.newAccount.title=Création de compte
+oauth2.newAccount.welcomeWithName=Bienvenue dans Dataverse, {0}
+oauth2.newAccount.welcomeNoName=Bienvenue dans Dataverse
+# oauth2.newAccount.email=Courriel
+# oauth2.newAccount.email.tip=Dataverse utilise ce courriel pour vous informer des problèmes liés à vos données.
+oauth2.newAccount.suggestedEmails=Adresses de courriel suggérées\u00A0:
+oauth2.newAccount.username=Nom d'utilisateur
+oauth2.newAccount.username.tip=Ce nom d'utilisateur sera votre identifiant unique en tant qu'utilisateur Dataverse.
+oauth2.newAccount.explanation=Cette information est fournie par {0} et sera utilisée pour créer votre compte {1}. Pour vous connecter à nouveau, vous devrez utiliser l'option de connexion {0}.
+oauth2.newAccount.suggestConvertInsteadOfCreate=Si vous avez déjà un compte {0}, vous devrez <a href="/oauth2/convert.xhtml"> convertir votre compte</a>.
+# oauth2.newAccount.tabs.convertAccount=Convertir un compte existant
+oauth2.newAccount.buttons.convertNewAccount=Convertir un compte
+oauth2.newAccount.emailTaken=Adresse courriel déjà prise. Envisagez plutôt de de fusionner le compte correspondant.
+oauth2.newAccount.emailOk=Adresse courriel validée.
+oauth2.newAccount.emailInvalid=Adresse courriel non valide.
+# oauth2.newAccount.usernameTaken=Nom d'utilisateur déjà pris.
+# oauth2.newAccount.usernameOk=Nom d'utilisateur validé.
 
 # oauth2/convert.xhtml
-# oauth2.convertAccount.title=Account Conversion
-oauth2.convertAccount.explanation=Please enter your {0} account username or email and password to convert your account to the {1} log in option. <a href="{2}/{3}/user/account.html" target="_blank">Learn more</a> about converting your account.
-oauth2.convertAccount.username=Existing username
-oauth2.convertAccount.password=Password
-oauth2.convertAccount.authenticationFailed=Authentication failed - bad username or password.
-oauth2.convertAccount.buttonTitle=Convert Account
-oauth2.convertAccount.success=Your Dataverse account is now associated with your {0} account.
+# oauth2.convertAccount.title=Conversion de compte
+oauth2.convertAccount.explanation=Entrez votre nom d'utilisateur {0} ou encore votre nom d'utilisateur et votre mot de passe pour convertir votre compte à l'option de connexion {1}. <a href="{2}/{3}/user/account.html" target="_blank">En apprendre davantage</a> à propos de la conversion de votre compte.
+oauth2.convertAccount.username=Nom d'utilisateur existant
+oauth2.convertAccount.password=Mot de passe
+oauth2.convertAccount.authenticationFailed=Authentification échouée - Nom d'utilisateur ou mot de passe incorrect.
+oauth2.convertAccount.buttonTitle=Convertir un compte
+oauth2.convertAccount.success=Votre compte Dataverse est maintenant associé à votre compte {0}.
 
 # oauth2/callback.xhtml
-oauth2.callback.page.title=OAuth Callback
-oauth2.callback.message=<strong>OAuth2 Error</strong> - Sorry, the identification process did not succeed.
+oauth2.callback.page.title=Rappel OAuth
+oauth2.callback.message=<strong>Erreur OAuth2</strong> - Désolé, le processus d'identification n'a pas réussi.
 
 # tab on dataverseuser.xhtml=
 apitoken.title=Jeton API
@@ -372,7 +372,7 @@ harvestclients.newClientDialog.type.Nesstar=Nesstar
 
 harvestclients.newClientDialog.url=URL du serveur
 harvestclients.newClientDialog.url.tip=URL d'une source moisssonnée.
-harvestclients.newClientDialog.url.watermark=URL du serveur moissonné distant, http://...
+harvestclients.newClientDialog.url.watermark=URL du serveur moissonné distant, http://\u2026
 harvestclients.newClientDialog.url.helptext.notvalidated=URL d'une source moisssonnée. Une fois le bouton « Suivant » cliqué, nous tenterons d'établir une connexion avec le serveur afin de vérifier qu'il fonctionne bien et obtenir des informations supplémentaires sur ses caractéristiques.
 harvestclients.newClientDialog.url.required=Une adresse valide de serveur à moissonner est requise.
 harvestclients.newClientDialog.url.invalid=URL non valide. Impossible d'établir une connexion et recevoir une réponse valide du serveur.
@@ -420,7 +420,7 @@ harvestclients.newClientDialog.harvestingStyle.helptext=Sélectionnez le type de 
 harvestclients.viewEditDialog.title=Modifier le client de moissonnage
 harvestclients.viewEditDialog.archiveUrl=URL du dépôt
 harvestclients.viewEditDialog.archiveUrl.tip=L'URL du dépôt qui fournit les données moisssonnées par ce client, laquelle est utilisée dans les résultats de recherche pour les liens vers les sources originales du contenu moissonné. 
-harvestclients.viewEditDialog.archiveUrl.helptext=Modifier si cette URL est différente de l'URL du serveur.
+harvestclients.viewEditDialog.archiveUrl.helptext=Modifier si cet URL est différent de l'URL du serveur.
 harvestclients.viewEditDialog.archiveDescription=Description du dépôt
 harvestclients.viewEditDialog.archiveDescription.tip=Description du dépôt source du contenu moissonné et affiché dans les résultats de recherche.
 harvestclients.viewEditDialog.archiveDescription.default.generic=Cet ensemble de de données est moissonné auprès de nos partenaires. En cliquant sur le lien, vous accédez directement au dépôt source des données.
@@ -436,7 +436,7 @@ harvestserver.service.enabled=Activé
 harvestserver.service.disabled=Désactivé
 harvestserver.service.disabled.msg=Le serveur de moissonnage est actuellement désactivé.
 harvestserver.service.empty=Aucun lot n'est configuré.
-harvestserver.service.enable.success=Le service OAI a été activé avec succès.
+harvestserver.service.enable.success=Le service OAI a bien été activé.
 
 harvestserver.noSets.why.header=Qu'est ce qu'un serveur de moissonnage?
 harvestserver.noSets.why.reason1=Le moissonnage consiste à échanger des métadonnées avec d'autres dépôts. En tant que  <b><i>serveur</i></b> de moissonnage, votre dataverse peut rendre disponible certains ensembles de données locaux à des clients de moissonnage distants. Il peut s'agir d'autres instances de Dataverse, ou encore de clients compatibles avec le protocole de moissonnage OAI-PMH.
@@ -481,13 +481,13 @@ harvestserver.newSetDialog.setdescription.required=La description de l'ensemble 
 
 harvestserver.newSetDialog.setquery=Requête de recherche
 harvestserver.newSetDialog.setquery.tip=Requête de recherche qui définit le contenu de l'ensemble de données.
-harvestserver.newSetDialog.setquery.helptext=Exemple de requête: authorName: king
+harvestserver.newSetDialog.setquery.helptext=Exemple de requête\u00A0: authorName:king
 harvestserver.newSetDialog.setquery.required=La requête de recherche ne peut être vide!
 harvestserver.newSetDialog.setquery.results=La requête de recherche a retourné {0} ensemble(s) de données!
-harvestserver.newSetDialog.setquery.empty=AVERTISSEMENT: la requête de recherche n'a retourné aucun résultat!
+harvestserver.newSetDialog.setquery.empty=AVERTISSEMENT\u00A0: la requête de recherche n'a retourné aucun résultat!
 
 harvestserver.newSetDialog.btn.create=Créer l'ensemble
-harvestserver.newSetDialog.success=L'ensemble de données "{0}" a été créé avec succès.
+harvestserver.newSetDialog.success=L'ensemble de données "{0}" a bien été créé.
 
 harvestserver.viewEditDialog.title=Modifier l'ensemble moissonné.
 harvestserver.viewEditDialog.btn.save=Sauvegarder les modifications
@@ -495,7 +495,7 @@ harvestserver.viewEditDialog.btn.save=Sauvegarder les modifications
 #MailServiceBean.java=
 
 notification.email.create.dataverse.subject=Dataverse\u00A0: Votre dataverse a été créé.
-notification.email.create.dataset.subject=Dataverse : Votre ensemble de données a été créé.
+notification.email.create.dataset.subject=Dataverse\u00A0: Votre ensemble de données a été créé.
 notification.email.request.file.access.subject=Dataverse\u00A0: Vous avez présenté une demande d'accès à un fichier en accès réservé.
 notification.email.grant.file.access.subject=Dataverse\u00A0: L'accès à un fichier réservé vous a été accordé.
 notification.email.rejected.file.access.subject=Dataverse\u00A0: Votre demande d'accès à un fichier en accès réservé a été refusée.
@@ -504,9 +504,9 @@ notification.email.submit.dataset.subject=Dataverse\u00A0: Votre ensemble de don
 notification.email.publish.dataset.subject=Dataverse\u00A0: Votre ensemble de données a été publié.
 notification.email.returned.dataset.subject=Dataverse\u00A0: Votre ensemble de données a été retourné.
 notification.email.create.account.subject=Dataverse\u00A0: Votre compte a été créé.
-notification.email.assign.role.subject=Dataverse:  Un rôle vous a été attribué
-notification.email.revoke.role.subject=Dataverse: Votre rôle a été révoqué
-notification.email.verifyEmail.subject=Dataverse: Valider votre adresse courriel
+notification.email.assign.role.subject=Dataverse\u00A0:  Un rôle vous a été attribué
+notification.email.revoke.role.subject=Dataverse\u00A0: Votre rôle a été révoqué
+notification.email.verifyEmail.subject=Dataverse\u00A0: Valider votre adresse courriel
 
 notification.email.greeting=Bonjour, \n
 
@@ -526,16 +526,16 @@ notification.email.wasReturnedByReviewer={0} (voir {1}) a été retourné par l'int
 notification.email.wasPublished={0} (voir {1}) a été publié dans {2} (voir {3}).
 notification.email.worldMap.added=Les données d'une couche WorldMap ont été ajoutées à {0} (voir {1}).
 notification.email.closing=\n\nMerci,\nScholars Portal Dataverse
-notification.email.assignRole=Vous êtes maintenant {0} pour: {1} "{2}" (voir {3}).
+notification.email.assignRole=Vous êtes maintenant {0} pour\u00A0: {1} "{2}" (voir {3}).
 notification.email.revokeRole=Un de vos rôles pour {0} "{1}" a été révoqué (voir {2}).
 notification.email.changeEmail=Bonjour, {0}.{1}\n\nVeuillez nous contacter si vous n'aviez pas l'intention de faire cette modification ou si vous avez besoin d'aide.
 hours=heures
 hour=heures
 minutes=minutes
 minute=minute
-notification.email.checksumfail.subject=Dataverse: Your upload failed checksum validation.
-notification.email.import.filesystem.subject=Dataverse: Your file import job has completed
-notification.email.import.checksum.subject=Dataverse: Your file checksum job has completed
+notification.email.checksumfail.subject=Dataverse\u00A0: votre validation de somme de contrôle a échouée.
+notification.email.import.filesystem.subject=Dataverse\u00A0: Votre tâche d'importation de fichier est complétée.
+notification.email.import.checksum.subject=Dataverse\u00A0: Votre tâche de somme de contrôle de fichier est complétée.
 
 # passwordreset.xhtml=
 
@@ -547,7 +547,7 @@ passwdReset.details={0} Réinitialisation du mot de passe{1} - Pour débuter le pr
 passwdReset.submitRequest=Soumettre la demande de mot de passe
 passwdReset.successSubmit.tip=Si cette adresse courriel est associée à un compte, un courriel sera envoyé avec des instructions supplémentaires à {0}.
 passwdReset.debug=DÉBOGUER
-passwdReset.resetUrl=L'adresse URL réinitialisée est
+passwdReset.resetUrl=L'adresse URL réinitialisé est
 passwdReset.noEmail.tip=Aucun courriel n'a été envoyé étant donné qu'aucun utilisateur n'a été trouvé au moyen de l'adresse fournie {0}. Nous ne le mentionnons pas, car nous voulons éviter que des utilisateurs malveillants se servent du formulaire pour déterminer si un compte est associé à une adresse courriel. 
 passwdReset.illegalLink.tip=Le lien pour réinitialiser votre mot de passe n'est pas valide. Si vous devez réinitialiser votre mot de passe, {0}cliquez ici{1} pour demander à ce que votre mot de passe soit réinitialisé.
 passwdReset.newPasswd.details={0} Nouveau mot de passe{1} \u2013 Veuillez choisir un mot de passe solide comptant au moins six caractères et au moins une lettre et un chiffre. 
@@ -557,7 +557,7 @@ passwdReset.resetBtn=Réinitialiser le mot de passe
 
 # dataverse.xhtml=
 
-dataverse.title=Le projet, le département, l'université ou le professeur visé par les données contenues dans le dataverse.
+dataverse.title=Le projet, le département, l'université ou le chercheur visé par les données contenues dans le dataverse.
 dataverse.enterName=Entrer le nom\u2026
 dataverse.host.title=Le dataverse qui contient ces données.
 dataverse.identifier.title=Nom abrégé utilisé pour l'adresse URL de ce dataverse.
@@ -565,7 +565,7 @@ dataverse.affiliation.title=L'organisation avec laquelle ce dataverse est affili
 
 dataverse.category=Catégorie
 dataverse.category.title=Le type correspondant le mieux à ce dataverse.
-dataverse.type.selectTab.top=Sélectionner...
+dataverse.type.selectTab.top=Sélectionner\u2026
 dataverse.type.selectTab.researchers=Chercheur
 dataverse.type.selectTab.researchProjects=Projet de recherche
 dataverse.type.selectTab.journals=Revue
@@ -635,8 +635,8 @@ dataverse.savedsearch.no.choice=Vous avez un dataverse pour lequel vous pouvez a
 dataverse.saved.search.success=La recherche sauvegardée est maintenant liée à {0}.
 dataverse.saved.search.failure=La recherche sauvegardée n'a pas pu être liée.
 dataverse.linked.success= {0} est maintenant lié à {1}.
-dataverse.linked.success.wait={0} a été lié avec succès à {1}. Veuillez attendre que le contenu s'affiche.
-dataverse.linked.internalerror={0} a été lié avec succès à {1} mais le contenu ne s'affichera pas avant qu'une erreur interne ne soit résolue.
+dataverse.linked.success.wait={0} a bien été lié à {1}. Veuillez attendre que le contenu s'affiche.
+dataverse.linked.internalerror={0} a bien été lié à {1} mais le contenu ne s'affichera pas avant qu'une erreur interne ne soit résolue.
 dataverse.page.pre=Précédent
 dataverse.page.next=Suivant
 dataverse.byCategory=Dataverses par catégorie
@@ -652,10 +652,10 @@ dataverse.delete=Supprimer le dataverse
 dataverse.delete.success=Votre dataverse a été supprimé.
 dataverse.delete.failure=Ce dataverse n'a pas pu être supprimé. 
 # Bundle file editors, please note that "dataverse.create.success" is used in a unit test because it's so fancy with two parameters=
-dataverse.create.success=Vous avez créé votre dataverse\ avec succès! Pour en savoir plus sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Dataverse Management - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
+dataverse.create.success=Vous avez bien réussi à créer votre dataverse! Pour en savoir davantage sur ce que vous pouvez faire avec votre dataverse, consultez le <a href="{0}/{1}/user/dataverse-management.html" title="Dataverse Management - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
 dataverse.create.failure=Ce dataverse n'a pas pu être créé. 
 dataverse.create.authenticatedUsersOnly=Seuls les utilisateurs authentifiés peuvent créer des dataverses.
-dataverse.update.success=Vous avez mis à jour votre dataverse avec succès!
+dataverse.update.success=Vous avez bien mis à jour votre dataverse!
 dataverse.update.failure=Ce dataverse n'a pas pu être mis à jour.
 
 # rolesAndPermissionsFragment.xhtml=
@@ -674,7 +674,7 @@ advanced.search.files.fileType=Type de fichier
 advanced.search.files.fileType.tip=L'extension d'un fichier, p.\u00A0ex. CSV, zip, Stata, R, PDF, JPEG, etc.
 advanced.search.files.variableName=Nom de la variable
 advanced.search.files.variableName.tip=Le titre de la colonne pour cette variable dans la table de données.
-advanced.search.files.variableLabel=Étiquette de variable
+advanced.search.files.variableLabel=Libellé de variable
 advanced.search.files.variableLabel.tip=Une courte description de la variable.
 
 # search-include-fragment.xhtml=
@@ -736,20 +736,20 @@ dataverse.theme.logo.alignment.selectTab.left=Gauche
 dataverse.theme.logo.alignment.selectTab.center=Centre
 dataverse.theme.logo.alignment.selectTab.right=Droite
 dataverse.theme.logo.backColor=Couleur du fond du logo
-dataverse.theme.logo.image.upload=Télécharger l'image
+dataverse.theme.logo.image.upload=Téléverser l'image
 dataverse.theme.tagline=Titre d'appel
 dataverse.theme.website=Site Web
 dataverse.theme.linkColor=Couleur du lien
 dataverse.theme.txtColor=Couleur du texte
 dataverse.theme.backColor=Couleur du fond
-dataverse.theme.success=Vous avez mis à jour avec succès le thème de ce dataverse!
+dataverse.theme.success=Vous avez bien mis à jour le thème de ce dataverse!
 dataverse.theme.failure=Le thème de ce dataverse n'a pas été mis à jour.
 dataverse.theme.logo.image=Image du logo
 dataverse.theme.logo.image.title=Le logo ou le fichier image que vous désirez afficher dans l'en-tête de ce dataverse.
-dataverse.theme.logo.image.uploadNewFile=Télécharger un nouveau fichier
-dataverse.theme.logo.image.invalidMsg=L'image ne peut pas être téléchargée. Veuillez essayer à nouveau en utilisant un fichier jpeg, tiff ou png.
-dataverse.theme.logo.image.uploadImgFile=Télécharger le fichier image
-dataverse.theme.logo.format.title=La forme du logo ou le fichier image que vous téléchargez pour ce dataverse.
+dataverse.theme.logo.image.uploadNewFile=Téléverser un nouveau fichier
+dataverse.theme.logo.image.invalidMsg=L'image ne peut pas être téléversée. Veuillez essayer à nouveau en utilisant un fichier jpeg, tiff ou png.
+dataverse.theme.logo.image.uploadImgFile=Téléverser le fichier image
+dataverse.theme.logo.format.title=La forme du logo ou le fichier image que vous téléversez pour ce dataverse.
 dataverse.theme.logo.format.selectTab.square2=Carré
 dataverse.theme.logo.format.selectTab.rectangle2=Rectangle
 dataverse.theme.logo.alignment.title=L'endroit où le logo ou l'image devrait apparaître dans l'en-tête
@@ -767,7 +767,7 @@ dataverse.theme.tagline.tip=Fournir un titre d'appel de 140 caractères ou moins.
 dataverse.theme.website.title=L'adresse URL de votre site Web personnel ou de votre établissement ou de tout site Web associé à ce dataverse.
 dataverse.theme.website.tip=Le lien pour le site Web se trouvera derrière le titre d'appel. Pour qu'un site Web apparaisse dans la liste, vous devez également fournir un titre d'appel 
 dataverse.theme.website.watermark=Votre site personnel, http://\u2026
-dataverse.theme.website.invalidMsg=Adresse URL non valide
+dataverse.theme.website.invalidMsg=Adresse URL non valide.
 
 dataverse.widgets.title=Widgets
 dataverse.widgets.notPublished.why.header=Pourquoi faire appel aux widgets?
@@ -783,13 +783,13 @@ dataverse.widgets.searchBox.txt=Boîte de recherche Dataverse
 dataverse.widgets.searchBox.tip=Permet aux visiteurs de votre site Web d'effectuer une recherche dans Dataverse.
 dataverse.widgets.dataverseListing.txt=Liste des dataverses
 dataverse.widgets.dataverseListing.tip=Permet aux visiteurs de votre site Web de voir vos dataverses et vos ensembles de données, de les trier ou de les parcourir en revue.
-dataverse.widgets.advanced.popup.header=Widgets : Options avancées
+dataverse.widgets.advanced.popup.header=Widgets\u00A0: Options avancées
 dataverse.widgets.advanced.prompt=Expédier vers votre site web personnel l'URL pérenne de la référence bibliographique de l'ensemble de données. La page que vous réferrez comme étant l'URL de votre site web personnel doit contenir l'extrait de code utilisé par le widget Listing de Dataverse.
 dataverse.widgets.advanced.url.label=URL de votre site web personnel
 dataverse.widgets.advanced.url.watermark=http://www.exemple.com/nom-de-la-page
-dataverse.widgets.advanced.invalid.message=Veuillez saisir une URL valide
+dataverse.widgets.advanced.invalid.message=Veuillez saisir un URL valide
 dataverse.widgets.advanced.success.message=Mise à jour réussie de l'URL de votre site web personnel
-dataverse.widgets.advanced.failure.message=L'URL du site web personnel associée à ce dataverse n'a pas été mis à jour.
+dataverse.widgets.advanced.failure.message=L'URL du site web personnel associé à ce dataverse n'a pas été mis à jour.
 
 # permissions-manage.xhtml=
 
@@ -847,7 +847,7 @@ dataverse.permissionsFiles.files.roleAssignees.label={0, option, 0#Utilisateurs/
 dataverse.permissionsFiles.files.assignBtn=Accorder l'accès
 dataverse.permissionsFiles.files.invalidMsg=Cet ensemble de données ne contient aucun fichier en accès réservé.
 dataverse.permissionsFiles.files.requested=Fichiers demandés
-dataverse.permissionsFiles.files.selected=Sélection: {0} de {1} {2}
+dataverse.permissionsFiles.files.selected=Sélection\u00A0: {0} de {1} {2}
 
 dataverse.permissionsFiles.viewRemoveDialog.header=Accès au fichier
 dataverse.permissionsFiles.viewRemoveDialog.removeBtn=Supprimer l'accès
@@ -927,7 +927,7 @@ dataset.manageTemplates.createBtn=Créer un modèle d'ensemble de données
 dataset.manageTemplates.saveNewTerms=Sauvegarder le modèle d'ensemble de données
 dataset.manageTemplates.noTemplates.why.header=Pourquoi utiliser des modèles?
 dataset.manageTemplates.noTemplates.why.reason1=Les modèles sont utiles lorsque vous possédez plusieurs ensembles de données pour lesquels les mêmes renseignements s'appliquent et que vous ne voulez pas avoir à les saisir manuellement à chaque fois.
-dataset.manageTemplates.noTemplates.why.reason2=Les modèles peuvent être utilisés pour entrer des directives à l'intention des personnes qui téléchargent des ensembles de données dans votre dataverse si vous désirez qu'un champ de métadonnées soit rempli d'une façon particulière. 
+dataset.manageTemplates.noTemplates.why.reason2=Les modèles peuvent être utilisés pour entrer des directives à l'intention des personnes qui téléversent des ensembles de données dans votre dataverse si vous désirez qu'un champ de métadonnées soit rempli d'une façon particulière. 
 dataset.manageTemplates.noTemplates.how.header=Comment utiliser les modèles
 dataset.manageTemplates.noTemplates.how.tip1=Les modèles sont créés au niveau du dataverse, peuvent être supprimés (si on ne veut pas qu'ils paraissent dans les futurs ensembles de données), sont activés par défaut (non requis) et peuvent être copiés de façon à ce que vous n'ayez pas à recommencer du début lorsque vous créez un nouveau modèle contenant des métadonnées similaires à un autre modèle. Lorsqu'un modèle est supprimé, il n'y a aucune incidence sur les ensembles de données qui ont déjà utilisé le modèle.
 dataset.manageTemplates.noTemplates.how.tip2=Veuillez noter que la possibilité de choisir les champs de métadonnées qui seront cachés, obligatoires ou facultatifs est disponible sur la page <a href="/dataverse/{0}?editMode=INFO" title="Dataverse General Information">Renseignements généraux</a> de ce dataverse.
@@ -996,7 +996,7 @@ dataverse.manageGroups.tab.action.btn.view=Voir
 dataverse.manageGroups.tab.action.btn.viewCollectedData=Voir les données colligées
 dataverse.manageGroups.tab.header.action=Action
 dataverse.manageGroups.tab.header.id=Identifiant du groupe
-dataverse.manageGroups.tab.header.membership=Membership
+dataverse.manageGroups.tab.header.membership=Adhésion
 dataverse.manageGroups.tab.header.name=Nom du groupe
 # manage-guestbooks.xhtml=
 
@@ -1006,7 +1006,7 @@ dataset.manageGuestbooks.createBtn=Créer un registre des visiteurs pour l'ensemb
 dataset.manageGuestbooks.download.all.responses=Télécharger toutes les entrées
 dataset.manageGuestbooks.download.responses=Télécharger les entrées
 dataset.manageGuestbooks.noGuestbooks.why.header=Pourquoi utiliser des registres de visiteurs?
-dataset.manageGuestbooks.noGuestbooks.why.reason1=Les registres de visiteurs vous permettent de recueillir des données sur les personnes qui téléchargent les fichiers de vos ensembles de données. Vous pouvez recueillir des renseignements issus du compte (nom d'utilisateur, prénom et nom, affiliation, etc.) et créer des questions personnalisées (p.\u00A0ex. À quoi serviront les données?)
+dataset.manageGuestbooks.noGuestbooks.why.reason1=Les registres de visiteurs vous permettent de recueillir des données au sujet des personnes qui téléchargent les fichiers de vos ensembles de données. Vous pouvez recueillir des renseignements issus du compte (nom d'utilisateur, prénom et nom, affiliation, etc.) et créer des questions personnalisées (p.\u00A0ex. À quoi serviront les données?)
 dataset.manageGuestbooks.noGuestbooks.why.reason2=Vous pouvez télécharger les données recueillies dans les registres de visiteurs activés afin de pouvoir les enregistrer en dehors de Dataverse.
 dataset.manageGuestbooks.noGuestbooks.how.header=Comment utiliser les registres de visiteurs
 dataset.manageGuestbooks.noGuestbooks.how.tip1=Un registre des visiteurs peut être utilisé pour plusieurs ensembles de données, mais un seul registre des visiteurs peut être utilisé pour un ensemble de données.
@@ -1076,12 +1076,12 @@ dataset.guestbookResponse.guestbook.responseTooLong=Veuillez limiter votre répon
 
 dataset.pageTitle=Ajouter un nouvel ensemble de données
 dataset.editBtn=Modifier
-dataset.editBtn.itemLabel.upload=Fichiers (télécharger)
+dataset.editBtn.itemLabel.upload=Fichiers (téléverser)
 dataset.editBtn.itemLabel.metadata=Métadonnées
 dataset.editBtn.itemLabel.terms=Conditions d'utilisation
 dataset.editBtn.itemLabel.permissions=Permissions
 dataset.editBtn.itemLabel.widgets=Widgets
-dataset.editBtn.itemLabel.privateUrl=URL privée
+dataset.editBtn.itemLabel.privateUrl=URL privé
 dataset.editBtn.itemLabel.permissionsDataset=Ensemble de données
 dataset.editBtn.itemLabel.permissionsFile=Fichiers à accès réservé
 dataset.editBtn.itemLabel.deleteDataset=Supprimer l'ensemble de données
@@ -1091,16 +1091,16 @@ dataset.exportBtn=Exporter les métadonnées
 dataset.exportBtn.itemLabel.ddi=DDI
 dataset.exportBtn.itemLabel.dublinCore=Dublin Core
 dataset.exportBtn.itemLabel.json=JSON
-metrics.title=Utilisations
-metrics.title.tip=View more metrics information
+metrics.title=Statistiques
+metrics.title.tip=Afficher plus d'informations sur les statistiques d'utilisation
 metrics.comingsoon=Bientôt disponible\u2026
-metrics.views=Pages vues
+metrics.views=Pages consultées
 metrics.downloads={0, choice, 0#téléchargements|1#téléchargement|2#téléchargements}
 metrics.citations=Citations
 metrics.shares=Partages
 dataset.publish.btn=Publier
 dataset.publish.header=Publier l'ensemble de données
-dataset.rejectBtn=Revenir à l'auteur
+dataset.rejectBtn=Retourner à l'auteur
 dataset.submitBtn=Soumettre aux fins d'examen
 dataset.disabledSubmittedBtn=Soumis aux fins d'examen
 dataset.submitMessage=Soumettre cet ensemble de données pour examen par l'intendant des données de ce dataverse en vue de publier.
@@ -1151,9 +1151,9 @@ dataset.keywordDisplay.title=Mot-clé
 dataset.subjectDisplay.title=Sujet
 dataset.contact.tip=Utiliser le bouton de courriel ci-dessus pour communiquer avec cette personne. 
 dataset.asterisk.tip=Les astérisques indiquent les champs obligatoires.
-dataset.message.uploadFiles=Charger les fichiers de l'ensemble de données - Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de chargement. 
-dataset.message.editMetadata=Modifier les métadonnées de l'ensemble de données : ajouter plus de métadonnées afin de faciliter le repérage de cet ensemble.
-dataset.message.editTerms=Modifier les conditions de l'ensemble de données: mettre à jour les conditions d'utilisation de cet ensemble de données.
+dataset.message.uploadFiles=Téléverser les fichiers de l'ensemble de données - Vous pouvez glisser-déplacer les fichiers à partir de votre ordinateur vers le widget de téléversement. 
+dataset.message.editMetadata=Modifier les métadonnées de l'ensemble de données\u00A0: ajouter plus de métadonnées afin de faciliter le repérage de cet ensemble.
+dataset.message.editTerms=Modifier les conditions de l'ensemble de données\u00A0: mettre à jour les conditions d'utilisation de cet ensemble de données.
 dataset.message.createSuccess=Cet ensemble de données a été créé.
 dataset.message.linkSuccess=Cet ensemble de données est maintenant lié à {1}.
 dataset.message.metadataSuccess=Les métadonnées pour cet ensemble de données ont été mises à jour.
@@ -1166,7 +1166,7 @@ dataset.message.bulkFileUpdateSuccess=Les fichiers sélectionnés ont été mis à jo
 datasetVersion.message.deleteSuccess=La version provisoire de cet ensemble de données a été supprimée.
 datasetVersion.message.deaccessionSuccess=La ou les versions sélectionnées ont été retirées.
 dataset.message.deaccessionSuccess=Cet ensemble de données a été retiré.
-dataset.message.files.ingestSuccess=Le ou les fichiers ont été chargés avec succès. Vous pouvez maintenant les consulter à l'aide de TwoRavens ou les télécharger en d'autres formats.
+dataset.message.files.ingestSuccess=Le(s) fichier(s) a(ont) bien été chargé(s). Vous pouvez maintenant les consulter à l'aide de TwoRavens ou les télécharger en d'autres formats.
 dataset.message.validationError=Erreur de validation - Les champs obligatoires ont été omis ou il y a eu une erreur de validation. Veuillez défiler le menu vers le bas pour voir les détails. 
 dataset.message.publishFailure=L'ensemble de données n'a pas pu être publié.
 dataset.message.metadataFailure=Les métadonnées n'ont pas pu être mises à jour.
@@ -1200,46 +1200,46 @@ dataset.mixedSelectedFilesForDownload=Le ou les fichiers réservés sélectionnés n
 dataset.downloadUnrestricted=Cliquez sur Continuer pour télécharger les fichiers pour lesquels vous avez un accès.
 dataset.requestAccessToRestrictedFiles=Vous pouvez demander l'accès à un ou des fichiers réservés en cliquant sur le bouton « Demander l'accès ».
 
-dataset.privateurl.infoMessageAuthor=URL privée de l'ensemble de données non publié - Partager en privé cet ensemble de données avant sa publication: {0}
-dataset.privateurl.infoMessageReviewer=URL privée de l'ensemble de données non publié -  Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
+dataset.privateurl.infoMessageAuthor=URL privé de l'ensemble de données non publié - Partager en privé cet ensemble de données avant sa publication\u00A0: {0}
+dataset.privateurl.infoMessageReviewer=URL privé de l'ensemble de données non publié -  Cet ensemble de données non publié est partagé en privé. Vous ne pourrez pas y accéder lorsque connecté à votre compte Dataverse.
 dataset.privateurl.header=URL privée de l'ensemble de données non publié
-dataset.privateurl.tip=Utilisez une adresse URL privée pour permettre à ceux qui n'ont pas de compte Dataverse d'accéder à votre ensemble de données non publié. Pour plus d'informations sur la fonctionnalité d'URL privée, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="Private URL for Reviewing an Unpublished Dataset - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
+dataset.privateurl.tip=Utilisez une adresse URL privée pour permettre à ceux qui n'ont pas de compte Dataverse d'accéder à votre ensemble de données non publié. Pour plus d'informations sur la fonctionnalité d'URL privé, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#private-url-for-reviewing-an-unpublished-dataset" title="Private URL for Reviewing an Unpublished Dataset - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
 dataset.privateurl.absent=L'adresse URL privée n'a pas été créée.
 dataset.privateurl.createPrivateUrl=Créer une adresse URL privée
-dataset.privateurl.disablePrivateUrl=Désactiver l'URL privée
-dataset.privateurl.disablePrivateUrlConfirm=Confirmer la désactivation de l'URL privée
-dataset.privateurl.disableConfirmationText=Voulez-vous vraiment désactiver l'URL privée? Si vous avez partagé l'URL privée avec d'autres utilisateurs, ceux-ci ne pourront plus l'utiliser pour accéder à votre ensemble de données non publié.
-dataset.privateurl.cannotCreate=L'URL privée ne peut être utilisée qu'avec des versions non publiées d'ensembles de données.
-dataset.privateurl.roleassigeeTitle=URL privée activée
+dataset.privateurl.disablePrivateUrl=Désactiver l'URL privé
+dataset.privateurl.disablePrivateUrlConfirm=Confirmer la désactivation de l'URL privé
+dataset.privateurl.disableConfirmationText=Voulez-vous vraiment désactiver l'URL privé? Si vous avez partagé l'URL privé avec d'autres utilisateurs, ceux-ci ne pourront plus l'utiliser pour accéder à votre ensemble de données non publié.
+dataset.privateurl.cannotCreate=L'URL privé ne peut être utilisé qu'avec des versions non publiées d'ensembles de données.
+dataset.privateurl.roleassigeeTitle=URL privé activé
 dataset.privateurl.createdSuccess=Opération réussie!
-dataset.privateurl.disabledSuccess=Vous avez désactivé avec succès l'URL privée de cet ensemble de données non publié.
-dataset.privateurl.noPermToCreate=Pour créer une adresse URL privée, vous devez disposer des autorisations suivantes: {0}.
+dataset.privateurl.disabledSuccess=Vous avez bien désactivé l'URL privé de cet ensemble de données non publié.
+dataset.privateurl.noPermToCreate=Pour créer une adresse URL privé, vous devez disposer des autorisations suivantes\u00A0: {0}.
 file.count={0} {0, choice, 0#Fichiers|1#Fichiers|2#Fichiers}
 file.count.selected={0} {0, choice, 0#Fichiers sélectionnés|1#Fichier sélectionné|2#Fichiers sélectionnés}
 file.selectToAddBtn=Sélectionner les fichiers à ajouter
-file.selectToAdd.tipLimit=La limite de téléchargement est de {0} octets par fichier.
+file.selectToAdd.tipLimit=La limite de téléversement est de {0} octets par fichier.
 file.selectToAdd.tipMoreInformation=Pour plus d'informations sur les formats de fichiers pris en charge, reportez-vous au <a href="{0}/{1}/user/dataset-management.html#file-handling-and-uploading" title="File Handling and Uploading - Dataverse User Guide" target="_blank">guide d'utilisation</a>.
-file.fromDropbox=Télécharger à partir de Dropbox
-file.fromDropbox.tip=Les fichiers peuvent aussi être téléchargés directement de Dropbox.
+file.fromDropbox=Téléverser à partir de Dropbox
+file.fromDropbox.tip=Les fichiers peuvent aussi être téléverser directement de Dropbox.
 file.fromDropbox.description=Glisser et déposer les fichiers ici.
 file.replace.original=Original File
 
 file.editFiles=Modifier les fichiers
 file.bulkUpdate=Chargement en lot
 file.uploadFiles=Téléverser des fichiers
-file.replaceFile=Replace File
+file.replaceFile=Remplacer le fichier
 file.notFound.tip=Cet ensemble de données ne contient aucun fichier.
 file.noSelectedFiles.tip=Aucun fichier n'a été sélectionné pour affichage. 
-file.noUploadedFiles.tip=Les fichiers chargés paraîtront ici. 
-file.replace=Replace
-file.replaced.warning.header=Edit File
-file.replaced.warning.draft.warningMessage=You can not replace a file that has been replaced in a dataset draft. In order to replace it with a different file you must delete the dataset draft. Note that doing so will discard any other changes within this draft.
-file.replaced.warning.previous.warningMessage=You can not edit a file that has been replaced in a previous dataset version. In order to edit it you must go to the most recently published version of the file.
-file.alreadyDeleted.previous.warningMessage=This file has already been deleted in current version. It may not be edited.
+file.noUploadedFiles.tip=Les fichiers téléversés paraîtront ici. 
+file.replace=Remplacer
+file.replaced.warning.header=Modifier le fichier
+file.replaced.warning.draft.warningMessage=Vous ne pouvez pas remplacer un fichier qui a été remplacé dans un ensemble de données provisoire. Pour le remplacer par un fichier différent, vous devez d'abord suppprimer l'ensemble de données provisoire. Notez que ce faisant, toute autre modification apportée à cet ensemble provisoire sera annulée.
+file.replaced.warning.previous.warningMessage=Vous ne pouvez pas éditer un fichier qui a été remplacé dans une version précédente d'un ensemble de données. Pour pouvoir l'éditer, vous devez accéder à la dernière version publiée du fichier. 
+file.alreadyDeleted.previous.warningMessage=Ce fichier a déjà été supprimé dans la version actuelle. Il peut ne pas être modifié.
 file.delete=Supprimer
 file.metadata=Métadonnées
 file.deleted.success=En cliquant sur «\u00A0Enregistrer les modifications\u00A0», les fichiers \u201C{0}\u201D seront supprimés de façon permanente de cette version de l'ensemble de données.
-file.deleted.replacement.success=The replacement file has been deleted.
+file.deleted.replacement.success=Le fichier de remplacement a été supprimé.
 file.editAccess=Modifier les accès
 file.restrict=Restreindre
 file.unrestrict=Sans restriction
@@ -1257,18 +1257,18 @@ file.metaData.dataFile.dataTab.variables=Variables,
 file.metaData.dataFile.dataTab.observations=Observations
 file.metaData.viewOnWorldMap=Explorer sur WorldMap
 file.addDescription=Ajouter une description du fichier\u2026
-file.tags=Étiquettes
-file.editTags=Étiquettes
-file.editTagsDialog.tip=Sélectionner les étiquettes de fichier existantes ou créer de nouvelles étiquettes pour décrire vos fichiers. Chaque fichier peut avoir plus d'une étiquette.
-file.editTagsDialog.select=Étiquettes de fichier
-file.editTagsDialog.selectedTags=Étiquettes sélectionnées
-file.editTagsDialog.selectedTags.none=Aucune étiquette sélectionnée
-file.editTagsDialog.add=Personnaliser l'étiquette du fichier
-file.editTagsDialog.add.tip=Créer une nouvelle étiquette l'ajoutera comme option d'étiquette pour tous les fichiers de cet ensemble de données.
-file.editTagsDialog.newName=Ajouter une nouvelle étiquette de fichier\u2026
-dataset.removeUnusedFileTags.label=Supprimer les étiquettes
-dataset.removeUnusedFileTags.tip=Sélectionner pour supprimer les étiquettes personnalisées non utilisées par les fichiers de l'ensemble de données.
-dataset.removeUnusedFileTags.check=Supprimer les étiquettes non utilisées
+file.tags=Libellés
+file.editTags=Libellés
+file.editTagsDialog.tip=Sélectionner les libellés de fichier existants ou créer de nouveaux libellés pour décrire vos fichiers. Chaque fichier peut avoir plus d'un libellé.
+file.editTagsDialog.select=Libellés de fichier
+file.editTagsDialog.selectedTags=Libellés sélectionnés
+file.editTagsDialog.selectedTags.none=Aucun libellé sélectionné
+file.editTagsDialog.add=Personnaliser le libellé du fichier
+file.editTagsDialog.add.tip=Créer un nouveau libellé l'ajoutera comme option de libellé pour tous les fichiers de cet ensemble de données.
+file.editTagsDialog.newName=Ajouter un nouveau libellé de fichier\u2026
+dataset.removeUnusedFileTags.label=Supprimer les libellés
+dataset.removeUnusedFileTags.tip=Sélectionner pour supprimer les libellés personnalisés non utilisés par les fichiers de l'ensemble de données.
+dataset.removeUnusedFileTags.check=Supprimer les libellés non utilisés
 
 file.setThumbnail=Sélectionner l'imagette  
 file.setThumbnail.header=Sélectionner l'imagette de l'ensemble de données
@@ -1278,14 +1278,14 @@ file.useThisIamge=Utiliser cette image comme imagette pour l'ensemble de données
 file.advancedOptions=Options avancées
 file.advancedIngestOptions=Options de chargement avancées
 file.assignedDataverseImage.success={0} a été sauvegardé(e) comme imagette pour cet ensemble de données. 
-file.assignedTabFileTags.success=Les étiquettes ont été ajoutées avec succès pour {0}.
-file.tabularDataTags=Étiquettes des données tabulaires
-file.tabularDataTags.tip=Sélectionner une ou plusieurs étiquettes décrivant le type de fichier de données.
+file.assignedTabFileTags.success=Les libellés ont bien été ajoutés pour {0}.
+file.tabularDataTags=Libellés des données tabulaires
+file.tabularDataTags.tip=Sélectionner un ou plusieurs libellés décrivant le type de fichier de données.
 file.spss-savEncoding=Encodage linguistique
 file.spss-savEncoding.title=Sélectionner la langue utilisée pour encoder ce fichier de données SPSS (sav).
-file.spss-savEncoding.current=Sélection actuelle :
-file.spss-porExtraLabels=Étiquettes de variable
-file.spss-porExtraLabels.title=Télécharger un fichier texte supplémentaire contenant des étiquettes de variable supplémentaires.
+file.spss-savEncoding.current=Sélection actuelle\u00A0:
+file.spss-porExtraLabels=Libellés de variable
+file.spss-porExtraLabels.title=Téléverser un fichier texte supplémentaire contenant des libellés de variable supplémentaires.
 file.spss-porExtraLabels.selectToAddBtn=Sélectionner le fichier à ajouter
 file.ingestFailed=Le chargement des données tabulaires a échoué.
 file.explore.twoRavens=TwoRavens
@@ -1299,11 +1299,11 @@ file.downloadBtn.format.original=Format du fichier original ({0})
 file.downloadBtn.format.rdata=Format RData
 file.downloadBtn.format.var=Métadonnées des variables
 file.downloadBtn.format.citation=Référence bibliographique du fichier de données
-file.more.information.link=Mettre un lien vers plus d'information sur le fichier: 
+file.more.information.link=Mettre un lien vers plus d'information sur le fichier\u00A0: 
 
 file.requestAccess=Demander l'accès
 file.requestAccess.dialog.msg=Vous devez <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
-file.requestAccess.dialog.msg.signup=Vous devez <a href="/dataverseuser.xhtml{0}&amp;editMode=CREATE" title="Sign Up for a Dataverse Account">vous créer un compte</a> ou <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
+file.requestAccess.dialog.msg.signup=Vous devez <a href="/dataverseuser.xhtml{0}&amp;editMode=CREATE" title="Inscrivez-vous pour ouvrir un compte Dataverse">vous créer un compte</a> ou <a href="/loginpage.xhtml{0}" title="vous connecter à votre compte Dataverse">vous authentifier</a> pour demander un accès à ce fichier.
 file.accessRequested=Accès demandé
 
 file.ingestInProgress=Chargement en cours\u2026
@@ -1314,7 +1314,7 @@ file.dataFilesTab.terms.header=Conditions
 file.dataFilesTab.terms.editTermsBtn=Modifier les conditions
 file.dataFilesTab.terms.list.termsOfUse.header=Conditions d'utilisation
 file.dataFilesTab.terms.list.termsOfUse.waiver=Licence accordée
-file.dataFilesTab.terms.list.termsOfUse.waiver.title=La licence permet d'informer les utilisateurs de ce qui leur est permis de faire avec ces données. 
+file.dataFilesTab.terms.list.termsOfUse.waiver.title=La licence permet d'informer les utilisateurs de ce qui leur est permis de faire avec ces données téléchargées. 
 file.dataFilesTab.terms.list.termsOfUse.waiver.txt=licence CC0 - \u201CTransfert dans le domaine public\u201D
 file.dataFilesTab.terms.list.termsOfUse.waiver.description=Les ensembles de données se verront attribuer par défaut une <a href="https\://creativecommons.org/publicdomain/zero/1.0/" title="Transfert dans le domaine public - Creative Commons" target="_blank">licence CC0 - Transfert dans le domaine public</a>. CC0 facilite la réutilisation des données de recherche. Les <a href="http\://best-practices.dataverse.org/harvard-policies/community-norms.html" title="Dataverse Community Norms - Dataverse Best Practices" target="_blank">normes de la communauté Dataverse</a> de même que les bonnes pratiques scientifiques exigent que toute source utilisée soit citée correctement. Si vous ne pouvez accorder une licence CC0, vous pouvez établir des conditions d'utilisation personnalisées pour vos ensembles de données. 
 file.dataFilesTab.terms.list.termsOfUse.no.waiver.txt=Aucune licence n'a été sélectionnée pour cet ensemble de données. 
@@ -1377,25 +1377,25 @@ file.dataFilesTab.terms.list.guestbook.noAvailable.tip=Aucun registre des visite
 file.dataFilesTab.terms.list.guestbook.clearBtn=Effacer la sélection
 
 file.dataFilesTab.versions=Versions
-file.dataFilesTab.versions.headers.dataset=Dataset
-file.dataFilesTab.versions.headers.summary=Summary
-file.dataFilesTab.versions.headers.contributors=Contributors
-file.dataFilesTab.versions.headers.published=Published
+file.dataFilesTab.versions.headers.dataset=Ensemble de données
+file.dataFilesTab.versions.headers.summary=Résumé
+file.dataFilesTab.versions.headers.contributors=Contributeurs
+file.dataFilesTab.versions.headers.published=Publié
 file.dataFilesTab.versions.viewDiffBtn=Voir les différences
 file.dataFilesTab.versions.citationMetadata=Métadonnées bibliographiques\u00A0:
 file.dataFilesTab.versions.added=Ajouté
 file.dataFilesTab.versions.removed=Supprimé
 file.dataFilesTab.versions.changed=Modifié
-file.dataFilesTab.versions.replaced=Replaced
+file.dataFilesTab.versions.replaced=Remplacé
 file.dataFilesTab.versions.original=Original
-file.dataFilesTab.versions.replacment=Replacement
+file.dataFilesTab.versions.replacment=Remplacement
 
 file.dataFilesTab.versions.additionalCitationMetadata=Métadonnées bibliographiques additionnelles\u00A0:
 file.dataFilesTab.versions.description.draft=Il s'agit d'une version provisoire.
 file.dataFilesTab.versions.description.deaccessioned=Étant donné que la version précédente a été retirée de la diffusion, aucune note sur les différences n'est disponible pour cette version publiée.
 file.dataFilesTab.versions.description.firstPublished=Il s'agit de la première version publiée.
 file.dataFilesTab.versions.description.deaccessionedReason=Raison du retrait\u00A0:
-file.dataFilesTab.versions.description.beAccessedAt=L'ensemble de données peut maintenant être consulté à :
+file.dataFilesTab.versions.description.beAccessedAt=L'ensemble de données peut maintenant être consulté à\u00A0:
 file.dataFilesTab.versions.viewDetails.btn=Voir les renseignements
 file.dataFilesTab.versions.widget.viewMoreInfo=Pour afficher plus d'informations sur les versions de cet ensemble de données et pour le modifier s'il s'agit de votre ensemble de données, consultez la <a href="/dataset.xhtml?persistentId = {0}" title="{1}" target="_blank"> version complète de cet ensemble</a> à  {2}.
 file.deleteDialog.tip=Êtes-vous sûr(e) de vouloir supprimer cet ensemble de données? Vous ne pourrez pas annuler la suppression.
@@ -1411,7 +1411,7 @@ file.deaccessionDialog.tip=Si vous retirez de la diffusion un ensemble de donnée
 file.deaccessionDialog.version=Version
 file.deaccessionDialog.reason.question1=Quelles versions désirez-vous retirer de la diffusion?
 file.deaccessionDialog.reason.question2=Quel est la raison du retrait?
-file.deaccessionDialog.reason.selectItem.identifiable=Il y a des données permettant l'identfication de personnes dans un ou plusieurs fichiers.
+file.deaccessionDialog.reason.selectItem.identifiable=Il y a des données permettant l'identification de personnes dans un ou plusieurs fichiers.
 file.deaccessionDialog.reason.selectItem.beRetracted=L'article de recherche a été retiré.
 file.deaccessionDialog.reason.selectItem.beTransferred=L'ensemble de données a été transféré dans un autre dépôt.
 file.deaccessionDialog.reason.selectItem.IRB=Demande du Comité d'éthique de la recherche
@@ -1431,8 +1431,8 @@ file.deaccessionDialog.dialog.url.tip=Veuillez indiquer une adresse URL de redir
 file.deaccessionDialog.dialog.url.header=Adresse URL non valide
 file.deaccessionDialog.dialog.textForReason.tip=Veuillez indiquer la raison du retrait.
 file.deaccessionDialog.dialog.textForReason.header=Entrer des renseignements supplémentaires
-file.deaccessionDialog.dialog.limitChar.tip=Le texte pour indiquer la raison du retrait ne peut dépasser 1\u00A0000\u00A0caractères.
-file.deaccessionDialog.dialog.limitChar.header=Limite de 1\u00A0000\u00A0caractères
+file.deaccessionDialog.dialog.limitChar.tip=Le texte pour indiquer la raison du retrait ne peut dépasser 1000 caractères.
+file.deaccessionDialog.dialog.limitChar.header=Limite de 1000 caractères
 file.viewDiffDialog.header=Renseignements sur les différences de version
 file.viewDiffDialog.dialog.warning=Veuillez sélectionner deux versions pour voir les différences.
 file.viewDiffDialog.version=Version 
@@ -1441,12 +1441,12 @@ file.viewDiffDialog.fileID=Identifiant du fichier
 file.viewDiffDialog.fileName=Nom
 file.viewDiffDialog.fileType=Type
 file.viewDiffDialog.fileSize=Taille
-file.viewDiffDialog.category=Étiquettes
+file.viewDiffDialog.category=Libellés
 file.viewDiffDialog.description=Description
-file.viewDiffDialog.fileReplaced=File Replaced
-file.viewDiffDialog.filesReplaced=File(s) Replaced
-file.viewDiffDialog.files.header=Files
-file.metadataTip=Conseil sur les métadonnées : Après avoir ajouté l'ensemble de données, cliquer sur le bouton «\u00A0Modifier l'ensemble de données\u00A0» pour ajouter plus de métadonnées.
+file.viewDiffDialog.fileReplaced=Fichier remplacé
+file.viewDiffDialog.filesReplaced=Fichier(s) remplacé(s)
+file.viewDiffDialog.files.header=Fichiers
+file.metadataTip=Conseil sur les métadonnées\u00A0: après avoir ajouté l'ensemble de données, cliquer sur le bouton «\u00A0Modifier l'ensemble de données\u00A0» pour ajouter plus de métadonnées.
 file.addBtn=Sauvegarder l'ensemble de données
 file.dataset.allFiles=Tous les fichiers de cet ensemble de données
 
@@ -1480,7 +1480,7 @@ dataset.widgets.citation.txt=Citation de l'ensemble de données
 dataset.widgets.citation.tip=Ajoutez la référence de votre ensemble de données à votre site personnel ou de projet.
 dataset.widgets.datasetFull.txt=Ensemble de données
 dataset.widgets.datasetFull.tip=Permet aux visiteurs de votre site web d'être en mesure d'afficher vos jeux de données, de télécharger des fichiers, etc.
-dataset.widgets.advanced.popup.header=Widgets : Options avancées
+dataset.widgets.advanced.popup.header=Widgets\u00A0: Options avancées
 dataset.widgets.advanced.prompt=Expédier vers votre site web personnel l'URL pérenne de la référence bibliographique de l'ensemble de données.
 dataset.widgets.advanced.url.label=URL de votre site web personnel
 dataset.widgets.advanced.url.watermark=http://www.exemple.com/nom-de-la-page
@@ -1497,13 +1497,13 @@ file.citation.label=Référence bibliographique
 file.cite.downloadBtn=Citer le fichier de données
 file.general.metadata.label=Métadonnées générales
 file.description.label=Description
-file.tags.label=Étiquettes
+file.tags.label=Libellés
 file.lastupdated.label=Dernière mise à jour
-file.DatasetVersion=Dataset Version
+file.DatasetVersion=Version de l'ensemble de données
 
 file.metadataTab.fileMetadata.header=Métadonnées du fichier
 file.metadataTab.fileMetadata.persistentid.label=Identifiant pérenne du fichier
-file.metadataTab.fileMetadata.downloadUrl.label=Download URL
+file.metadataTab.fileMetadata.downloadUrl.label=URL de téléchargement
 file.metadataTab.fileMetadata.unf.label=UNF
 file.metadataTab.fileMetadata.size.label=Taille
 file.metadataTab.fileMetadata.type.label=Catégorie
@@ -1514,80 +1514,81 @@ file.metadataTab.fitsMetadata.header=Métadonnées FITS
 file.metadataTab.provenance.header=Provenance du fichier
 file.metadataTab.provenance.body=Information sur la provenance des fichiers à venir dans une version ultérieure\u2026
 
-file.versionDifferences.noChanges=No changes associated with this version
-file.versionDifferences.fileNotInVersion=File not included in this version
-file.versionDifferences.actionChanged=Changed
-file.versionDifferences.actionAdded=Added
-file.versionDifferences.actionRemoved=Removed
-file.versionDifferences.actionReplaced=Replaced
-file.versionDifferences.fileMetadataGroupTitle=File Metadata
-file.versionDifferences.fileTagsGroupTitle=File Tags
+file.versionDifferences.noChanges=Aucun changement associé à cette version
+file.versionDifferences.fileNotInVersion=Fichier non inclus dans cette version
+file.versionDifferences.actionChanged=Changé
+file.versionDifferences.actionAdded=Ajouté
+file.versionDifferences.actionRemoved=Supprimé
+file.versionDifferences.actionReplaced=Remplacé
+file.versionDifferences.fileMetadataGroupTitle=Métadonnées du fichier
+file.versionDifferences.fileTagsGroupTitle=Libellés du fichier
 file.versionDifferences.descriptionDetailTitle=Description
-file.versionDifferences.fileNameDetailTitle=File Name
-file.versionDifferences.fileAccessTitle=File Access
-file.versionDifferences.fileRestricted=Restricted
-file.versionDifferences.fileUnrestricted=Unrestricted
-file.versionDifferences.fileGroupTitle=File
+file.versionDifferences.fileNameDetailTitle=Nom du fichier
+file.versionDifferences.fileAccessTitle=Accès aux fichiers
+file.versionDifferences.fileRestricted=Accès réservé
+file.versionDifferences.fileUnrestricted=Accès sans restrictions
+file.versionDifferences.fileGroupTitle=Fichier
 
 # editdatafile.xhtml
 
 # editFilesFragment.xhtml
-file.edit.error.file_exceeds_limit=This file exceeds the size limit.
+file.edit.error.file_exceeds_limit=Ce fichier dépasse la taille limite.
 # File metadata error
-file.metadata.datafiletag.not_tabular=You cannot add Tabular Data Tags to a non-tabular file.
+file.metadata.datafiletag.not_tabular=Vous ne pouvez pas ajouter de libellés de données tabulaires à un fichier non tabulaire.
 
 # File Edit Success
-file.message.editSuccess=This file has been updated.
-file.message.replaceSuccess=This file has been replaced.
+file.message.editSuccess=Ce fichier a été mis à jour.
+file.message.replaceSuccess=Ce fichier a été remplacé.
 
 # File Add/Replace operation messages
-file.addreplace.file_size_ok=File size is in range.
-file.addreplace.error.file_exceeds_limit=This file size ({0}) exceeds the size limit of {1} bytes.
-file.addreplace.error.dataset_is_null=The dataset cannot be null.
-file.addreplace.error.dataset_id_is_null=The dataset ID cannot be null.
-find.dataset.error.dataset_id_is_null=When accessing a dataset based on Persistent ID, a {0} query parameter must be present.
-find.dataset.error.dataset.not.found.persistentId=Dataset with Persistent ID {0} not found.
-find.dataset.error.dataset.not.found.id=Dataset with ID {0} not found.
-find.dataset.error.dataset.not.found.bad.id=Bad dataset ID number: {0}.
-file.addreplace.error.dataset_id_not_found=There was no dataset found for ID: 
-file.addreplace.error.no_edit_dataset_permission=You do not have permission to edit this dataset.
-file.addreplace.error.filename_undetermined=The file name cannot be determined.
-file.addreplace.error.file_content_type_undetermined=The file content type cannot be determined.
-file.addreplace.error.file_upload_failed=The file upload failed.
-file.addreplace.error.duplicate_file=This file already exists in the dataset. 
-file.addreplace.error.existing_file_to_replace_id_is_null=The ID of the existing file to replace must be provided.
-file.addreplace.error.existing_file_to_replace_not_found_by_id=Replacement file not found. There was no file found for ID: {0}
-file.addreplace.error.existing_file_to_replace_is_null=The file to replace cannot be null.
-file.addreplace.error.existing_file_to_replace_not_in_dataset=The file to replace does not belong to this dataset.
-file.addreplace.error.existing_file_not_in_latest_published_version=You cannot replace a file that is not in the most recently published dataset. (The file is unpublished or was deleted from a previous version.)
-file.addreplace.content_type.header=File Type Different
-file.addreplace.error.replace.new_file_has_different_content_type=The original file ({0}) and replacement file ({1}) are different file types.
-file.addreplace.error.replace.new_file_same_as_replacement=You cannot replace a file with the exact same file.
-file.addreplace.error.unpublished_file_cannot_be_replaced=You cannot replace an unpublished file. Please delete it instead of replacing it.
-file.addreplace.error.ingest_create_file_err=There was an error when trying to add the new file.
-file.addreplace.error.initial_file_list_empty=An error occurred and the new file was not added.
-file.addreplace.error.initial_file_list_more_than_one=You cannot replace a single file with multiple files. The file you uploaded was ingested into multiple files.
-file.addreplace.error.final_file_list_empty=There are no files to add. (This error should not happen if steps called in sequence.)
-file.addreplace.error.only_replace_operation=This should only be called for file replace operations!
-file.addreplace.error.failed_to_remove_old_file_from_dataset=Unable to remove old file from new DatasetVersion.
-file.addreplace.error.add.add_file_error=Failed to add file to dataset.
-file.addreplace.error.phase2_called_early_no_new_files=There was an error saving the dataset - no new files found.
-file.addreplace.success.add=File successfully added!
-file.addreplace.success.replace=File successfully replaced!
-file.addreplace.error.auth=The API key is invalid.
-file.addreplace.error.invalid_datafile_tag=Not a valid Tabular Data Tag: 
+file.addreplace.file_size_ok=La taille du fichier est appropriée.
+file.addreplace.error.file_exceeds_limit=La taille de ce fichier ({0}) dépasse la limite de taille de {1} octet(s).
+file.addreplace.error.dataset_is_null=L'ensemble de données ne peut être nul.
+file.addreplace.error.dataset_id_is_null=L'identifiant de l'ensemble de données ne peut être nul.
+find.dataset.error.dataset_id_is_null=L'accès à un ensemble de données basé sur un identifiant pérenne requiert qu'un paramètre de requête {0} soit présent.
+find.dataset.error.dataset.not.found.persistentId=L'ensemble de données basé sur l'identifiant pérenne {0} est introuvable.
+find.dataset.error.dataset.not.found.id=L'ensemble de données avec l'identifiant {0} est introuvable.
+find.dataset.error.dataset.not.found.bad.id=Numéro d'identifiant de l'ensemble de données incorrect\u00A0: {0}.
+file.addreplace.error.dataset_id_not_found=Aucun ensemble de données n'a été trouvé pour l'identifiant\u00A0:
+file.addreplace.error.no_edit_dataset_permission=Vous n'avez pas la permission de modifier cet ensemble de données.
+file.addreplace.error.filename_undetermined=Le nom du fichier ne peut être établi.
+file.addreplace.error.file_content_type_undetermined=Le type de contenu du fichier ne peut être établi.
+file.addreplace.error.file_upload_failed=Le téléversement du fichier a échoué.
+file.addreplace.error.duplicate_file=Ce fichier existe déjà dans l'ensemble de données. 
+file.addreplace.error.existing_file_to_replace_id_is_null=L'identifiant du fichier existant à remplacer doit être fourni.
+file.addreplace.error.existing_file_to_replace_not_found_by_id=Fichier de remplacement non trouvé. Aucun fichier n'a été trouvé pour l'identifiant\u00A0: {0}
+file.addreplace.error.existing_file_to_replace_is_null=Le fichier à remplacer ne peut être nul.
+file.addreplace.error.existing_file_to_replace_not_in_dataset=Le fichier à remplacer n'appartient pas à cet ensemble de données.
+file.addreplace.error.existing_file_not_in_latest_published_version=Vous ne pouvez pas remplacer un fichier qui n'est pas dans le dernier ensemble de données publié. (Le fichier est non publié ou a été supprimé d'une version précédente.)
+file.addreplace.content_type.header=Type de fichier différent
+file.addreplace.error.replace.new_file_has_different_content_type=Le fichier d'origine ({0}) et le fichier de remplacement ({1}) sont des types de fichiers différents.
+file.addreplace.error.replace.new_file_same_as_replacement=Vous ne pouvez pas remplacer un fichier avec exactement le même fichier.
+file.addreplace.error.unpublished_file_cannot_be_replaced=Vous ne pouvez pas remplacer un fichier non publié. Supprimez-le au lieu de le remplacer.
+file.addreplace.error.ingest_create_file_err=Une erreur s'est produite lors de l'ajout du nouveau fichier.
+file.addreplace.error.initial_file_list_empty=Une erreur s'est produite et le nouveau fichier n'a pas été ajouté.
+file.addreplace.error.initial_file_list_more_than_one=Vous ne pouvez pas remplacer un seul fichier par plusieurs fichiers. Le fichier que vous avez téléversé a été ingéré dans plusieurs fichiers.
+file.addreplace.error.final_file_list_empty=Il n'y a pas de fichiers à ajouter. (Cette erreur ne devrait pas se produire si la séquence des étapes a été respectée.)
+file.addreplace.error.only_replace_operation=Ceci ne devrait être appelé que pour les opérations de remplacement de fichier!
+file.addreplace.error.failed_to_remove_old_file_from_dataset=Impossible de retirer un ancien fichier du nouvel ensemble de données versionné.
+file.addreplace.error.add.add_file_error=Impossible d'ajouter un fichier à l'ensemble de données.
+file.addreplace.error.phase2_called_early_no_new_files=Une erreur s'est produite lors de l'enregistrement de l'ensemble de données. Aucun nouveau fichier n'a été trouvé.
+file.addreplace.success.add=Le fichier a bien été ajouté!
+file.addreplace.success.replace=Le fichier a bien été remplacé!
+file.addreplace.error.auth=La clé API n'est pas valide.
+file.addreplace.error.invalid_datafile_tag=Libellé de données tabulaires non valide\u00A0: 
 
 # 500.xhtml
-error.500.page.title=500 Erreur interne du serveur
+error.500.page.title=500 - Erreur interne du serveur
 error.500.message=<strong>Erreur interne du serveur</strong> - Une erreur inattendue s'est produite, aucune information supplémentaire n'est disponible. 
 
 # 404.xhtml=
-error.404.page.title=404 Page non trouvée
+error.404.page.title=404 - Page non trouvée
 error.404.message=<strong>Page non trouvée</strong> - La page que vous cherchez n'a pas été trouvée. 
 
-
-error.403.page.title=403 Non autorisé
+# 403.xhtml
+error.403.page.title=403 - Non autorisé
 error.403.message=<strong>Non autorisé</strong> - Vous n'êtes pas autorisé à voir cette page.
+
 # general error - support message=
 error.support.message=Si vous pensez qu'il s'agit d'une erreur, veuillez contacter {0} pour obtenir de l'aide.
 
@@ -1598,56 +1599,57 @@ citationFrame.banner.closeIcon=Fermer ce message, aller dans l'ensemble de donné
 citationFrame.banner.countdownMessage= Ce message se fermera dans 
 citationFrame.banner.countdownMessage.seconds=secondes
 
-
 # EditDatafilesPage.java
-file.edit.duplicate.message =The following file is a duplicate of an already uploaded file:
-file.edit.duplicates.message =The following files are duplicates of (an) already uploaded file(s):
-file.edit.exist.message =The following files already exist in the dataset:
-file.edit.skip.message =(skipping)
+file.edit.duplicate.message =Le fichier suivant est un doublon d'un fichier déjà téléversé\u00A0: 
+file.edit.duplicates.message =Les fichiers suivants sont des doublons d'un (de) fichier(s) déjà téléversé(s)\u00A0: 
+file.edit.exist.message =Les fichiers suivants font déjà partie de l'ensemble de données\u00A0: 
+file.edit.skip.message =(ignoré)
 
 # DTA117FileReader.java
-dta.datafile.error = this plugin does not support external raw data files
-dta.readheader.error = Unexpected version tag found: {0}; expected value: 117.
-dta.datasettimestamp.error=unexpected/invalid length of the time stamp in the DTA117 header.
-dta.variabletype.label.error=Unrecognized type label: {0} for Stata type value (short) {1}.
-dta.variabletype.value.error=unknown variable type value encountered: {0}
-dta.vartype.error=Undefined variable type encountered in readData()
-dta.datasection.error=unknown variable type encounted when reading data section: {0}
-dta.byteoffset.error=Unexpected number of bytes read for data row {0}; {1} expected, {2} read.
-dta.readSTRLs.failure=Failed to read an intermediate v,o Pair for variable {0}, observation {1}
-dta.readSTRLs.illegal=Illegal v,o value: {0} for variable {1}, observation {2}
-dta.readGSO.failure=Failed to read GSO value for {0}
-dta.readGSO.string.error=GSO string unavailable for v,o value {0}
-dta.readlabels.total.error = read mismatch in readLabels()
-dta.readlabels.value.error=read mismatch in readLabels() 2
-dta.calculatebytes.length.error=internal variable byte offsets table not properly configured
-dta.calculatebytes.offset.error=bad variable byte offset: {0}
-dta.variabletypes.error=internal variable types not properly configured
-dta.variabletype.error=empty variable type in attempted byte length lookup.
-dta.invalidstrf.error =Invalid STRF encountered: {0}
-dta.unknown.variable=Unknown or invalid variable type: {0} 
-dta.readbytes.error=DataReader.readBytes called to read zero or negative number of bytes.
-dta.readbytes.buffer=TD - buffer overflow
-dta.readbytes.premature=reached the end of data stream prematurely.
-dta.readdoubleInt.error=Byte order not determined for reading numeric values. 
-dta.bytestoint.error=Unsupported number of bytes in an integer: {0}
-dta.bytestosignedInt.error=Unsupported number of bytes for signed integer: {0}
-dta.bytestolong.error=Wrong number of bytes in bytesToLong().
-dta.characterlimit.error=more than limit characters in the section tag
-dta.negativenumber.error=negative number of bytes in skipDefinedSection(tag) 
-dta.opentag.error=opening tag must be a non-empty string.
-dta.sectiontag.error=Checking section tags across byte buffers not yet implemented.
-dta.opentag.missing=Could not read opening tag {0}
-dta.closetag.error=closing tag must be a non-empty string.
-dta.closetag.missing=Could not read closing tag {0}
-dta.bufferoverflow.error =Buffer overflow in DataReader.
+dta.datafile.error = ce module d'extension (plugin) ne prend pas en charge les fichiers externes de données brutes 
+dta.readheader.error = Libellé de version inattendue trouvé\u00A0: {0}; valeur attendue\u00A0: 117.
+dta.datasettimestamp.error=Longueur invalide/inattendue de l'horodatage dans l'en-tête du DTA117.
+dta.variabletype.label.error=Libellé de type non reconnu\u00A0: {0} pour le type de valeur Stata (court) {1}.
+dta.variabletype.value.error=valeur de type de variable inconnue rencontrée\u00A0: {0}
+dta.vartype.error=Type de variable indéfini rencontré dans readData()
+dta.datasection.error=Type de variable inconnu rencontré lors de la lecture de la section de données\u00A0: {0}
+dta.byteoffset.error=Nombre inattendu d'octets lus pour la rangée de données {0}; {1} attendu(s), {2} lu(s).
+dta.readSTRLs.failure=Impossible de lire une paire intermédiaire v,o pour la variable {0}, observation {1}
+dta.readSTRLs.illegal=Valeur v,o interdite\u00A0: {0} pour la variable {1}, observation {2}
+dta.readGSO.failure=Impossible de lire la valeur GSO pour {0}
+dta.readGSO.string.error=Chaîne GSO indisponible pour la valeur v,o {0}
+dta.readlabels.total.error = incompatibilité de lecture dans readLabels()
+dta.readlabels.value.error=incompatibilité de lecture dans readLabels() 2
+dta.calculatebytes.length.error=Le tableau des variables internes de décalages d'octets n'est pas correctement configuré
+dta.calculatebytes.offset.error=variable de décalage d'octet incorrect\u00A0: {0}
+dta.variabletypes.error=Les types de variables internes ne sont pas correctement configurés
+dta.variabletype.error=Type de variable vide dans la tentative de recherche sur la longueur d'octet.
+dta.invalidstrf.error =STRF invalide rencontré\u00A0: {0}
+dta.unknown.variable=Type de variable inconnue ou invalide\u00A0: {0} 
+dta.readbytes.error=DataReader.readBytes appelé à lire un nombre d'octets négatifs ou égal à 0.
+dta.readbytes.buffer=TD - Surcharge de mémoire tampon 
+dta.readbytes.premature=a atteint la fin du flux de données prématurément.
+dta.readdoubleInt.error=Ordre d'octet non déterminé pour la lecture de valeurs numériques. 
+dta.bytestoint.error=Nombre d'octets non pris en charge dans un entier\u00A0: {0}
+dta.bytestosignedInt.error=Nombre d'octets non pris en charge pour entier signé\u00A0: {0}
+dta.bytestolong.error=Nombre erroné d'octets dans bytesToLong().
+dta.characterlimit.error=limite atteinte pour le nombre de caractères dans la balise de section
+dta.negativenumber.error=Nombre d'octets négatifs dans skipDefinedSection(balise) 
+dta.opentag.error=la balise d'ouverture doit être une chaîne non vide.
+dta.sectiontag.error=Vérification des balises de section sur les tampons d'octets non encore implémentée.
+dta.opentag.missing=Impossible de lire la balise d'ouverture {0}
+dta.closetag.error=la balise de fermeture doit être une chaîne non vide.
+dta.closetag.missing=Impossible de lire la balise de fermeture {0}
+dta.bufferoverflow.error =Surcharge de mémoire tampon dans le DataReader.
 
 
 # New labels
+
 main_dataverse_create=Créer mon Dataverse
 main_or=ou
 main_explore=Explorer
 main_search=Chercher
+
 
 #EMailValidator
 emailvalidator.notValid={0} n'est pas une adresse courriel valide.
@@ -1782,7 +1784,7 @@ Life\u0020Sciences\u0020Metadata=Métadonnées des sciences de la vie
 Journal\u0020Metadata=Métadonnées de la revue
 
 file.dataFilesTab.fileRestrictions=Restrictions relatives aux fichiers
-datset.replicationDataFor=Données de réplication pour:
+datset.replicationDataFor=Données de réplication pour\u00A0:
 
 #Permission.java
 permission.addDataverseDataverse=Ajouter un dataverse à l'intérieur d'un autre dataverse
@@ -1809,7 +1811,7 @@ permission.roleAssignedToFor=Rôle {0} attribué à {1} pour {2}.
 permission.roleNotAbleToBeAssigned=II a été impossible d'attribuer le rôle.
 permission.defaultPermissionDataverseUpdated=Les autorisations par défaut pour ce dataverse ont été mises à jour.
 permission.CannotAssigntDefaultPermissions=Impossible d'attribuer des autorisations par défaut. 
-permission.errorAssigningRole=Erreur dans l'attribution du rôle: {0}
+permission.errorAssigningRole=Erreur dans l'attribution du rôle\u00A0: {0}
 permission.updated=mis à jour
 permission.created=créé
 permission.roleWas=Le rôle était {0}. Pour l'attribuer à un utilisateur et/ou un groupe, cliquez sur le bouton « Attribuer un rôle à un utilisateur/un groupe » dans la section Utilisateurs/Groupes de cette page. 
@@ -1834,13 +1836,13 @@ Password=Mot de passe
 #search-include-fragment.xhtml bundle[facetCategory.friendlyName]
 Dataverse\u0020Category=Catégorie Dataverse
 Publication\u0020Date=Date de publication
-Author-Name=Nom de-l'auteur
+Author-Name=Nom \u2014 Auteur
 Subject=Sujet
 Deposit\u0020Date=Date de dépôt
 File\u0020Type=Type de fichier
-File\u0020Tag=Étiquette de fichier
+File\u0020Tag=Libellé de fichier
 Access=Accès
-Keyword-Term=Mot-clé-Terme
+Keyword-Term=Mot-clé \u2014 Terme
 Author\u0020Affiliation=Affiliation de l'auteur
 Language=Langue
 Kind\u0020of\u0020Data=Type de données
@@ -1856,7 +1858,7 @@ mydataFragment.moreResults=Voir plus de résultats
 mydataFragment.publicacionStatus=Statut de publication
 mydataFragment.roles=Rôles
 mydataFragment.resultsByUserName=Résultats par utilisateur
-mydataFragment.search=Chercher dans mes données...
+mydataFragment.search=Chercher dans mes données\u0026
 
 Published=Publié
 Unpublished=Non publié
@@ -1891,8 +1893,8 @@ Time\u0020Period\u0020Covered\u0020End=Fin de la période couverte
 Series\u0020Name=Nom de la série
 
 #SystemConfig
-system.app.terms=Il n'y a pas de Conditions d'utilisation associées à cette installation de Dataverse. 
-system.api.terms=Il n'y a pas de Conditions d'utilisation des API associées à cette installation de Dataverse. 
+system.app.terms=Il n'y a pas de conditions d'utilisation associées à cette installation de Dataverse. 
+system.api.terms=Il n'y a pas de conditions d'utilisation des API associées à cette installation de Dataverse. 
 
 #messages.xhtml
 iqbs.message.validationErrorStrong=<strong>Erreur de validation</strong> - Les champs obligatoires ont été omis ou il y a eu une erreur de validation. Veuillez défiler le menu vers le bas pour voir les détails. 
@@ -1912,17 +1914,17 @@ login.Password=Veuillez entrer un mot de passe.
 passwordReset.initiated=Réinitialisation du mot de passe amorcée
 
 # BuiltinUserPage
-userPage.informationUpdated=L'information associée à votre compte a été mise à jour avec succès.
-userPage.passwordChanged=Votre mot de passe a été modifié avec succès.
+userPage.informationUpdated=L'information associée à votre compte a bien été mise à jour.
+userPage.passwordChanged=Votre mot de passe a bien été modifié.
 userPage.usernameIncorrect=Erreur dans le nom d'utilisateur ou l'adresse courriel.
 userPage.passwordStillNull=Aucune valeur associée à InputPassword 
 userPage.passwordNotComplex=Le mot de passe n'est pas suffisamment complexe. Le mot de passe doit comprendre au minimum une lettre, un chiffre et contenir au moins  {0} caractères. 
 userPage.newPasswordNotBlank=le nouveau mot de passe n'est pas vide
-userPage.newPasswordBlankRetype=Le nouveau mot de passe est vide: saisir à nouveau.
+userPage.newPasswordBlankRetype=Le nouveau mot de passe est vide\u00A0: saisir à nouveau.
 userPage.newPasswordBlank=le nouveau mot de passe est vide
 userPage.passwordIncorrect=Le mot de passe est incorrect.
 userPage.passwordNotBlank=le mot de passe actuel n'est pas vide
-userPage.passwordBlankRetype=Le mot de passe est vide: saisir à nouveau.
+userPage.passwordBlankRetype=Le mot de passe est vide\u00A0: saisir à nouveau.
 userPage.passwordError=Erreur de mot de passe
 userPage.passwordBlank=le mot de passe actuel est vide
 
@@ -1941,11 +1943,11 @@ dataset.category.code=Code
 Researcher=Chercheur
 Research\u0020Project=Projet de recherche
 Journal=Revue
-Organizations\u0020or\u0020Insitutions=Organisation ou établissement
+Organizations\u0020or\u0020Institutions=Organisation ou établissement
 Teaching\u0020Course=Cours
 Uncategorized=Sans catégorie
-Research\u0020Group=Research Group
-Laboratory=Laboratory 
+Research\u0020Group=Groupe de recherche
+Laboratory=Laboratoire 
 
 Agricultural\u0020Sciences=Sciences de l\u2019agriculture
 Arts\u0020and\u0020Humanities=Arts et sciences humaines

--- a/src/main/java/Bundle_fr.properties
+++ b/src/main/java/Bundle_fr.properties
@@ -333,12 +333,12 @@ harvestclients.toptip= - Le moissonnage peut être planifié pour s'exécuter selon
 harvestclients.noClients.label=Aucun client n'est configuré.
 harvestclients.noClients.why.header=Qu'est-ce que le moissonnage?
 harvestclients.noClients.why.reason1=Le moissonnage consiste à échanger des métadonnées avec d'autres dépôts. En tant que  <b><i>client</i></b> de moissonnage, votre Dataverse peut recueillir les métadonnées de notices provenant de sources distantes. Il peut s'agir d'autres instances de Dataverse, ou encore de dépôts compatibles avec le protocole OAI-PMH, soit le protocole standard de moissonnage. 
-harvestclients.noClients.why.reason2=Les notices de métadonnées moissonnées sont interrogeables par les usagers. En cliquant sur un ensemble de données moissonné dans la liste des résultats de recherche, l'usager peut accéder au dépôt d'origine. Les ensembles de données moissonnés ne peuvent cependant être modifiés dans votre instance de Dataverse. 
+harvestclients.noClients.why.reason2=Les notices de métadonnées moissonnées sont interrogeables par les usagers. En cliquant sur un ensemble de données moissonné dans la liste des résultats de recherche, l'usager peut accéder au dépôt d'origine. Les ensembles de données moissonnés ne peuvent cependant pas être modifiés dans votre instance de Dataverse. 
 harvestclients.noClients.how.header=Comment effectuer le moissonnage
-harvestclients.noClients.how.tip1=Afin de pouvoir moissonner des métadonnées, un <i>client de moissonnage</i> doit être défini et paramétré pour chacuns des dépôts distants. Veuillez noter que pour définir un client, vous devrez sélectionner un Dataverse local déjà existant, lequel hébergera les ensembles de données moissonnés.
+harvestclients.noClients.how.tip1=Afin de pouvoir moissonner des métadonnées, un <i>client de moissonnage</i> doit être défini et paramétré pour chacun des dépôts distants. Veuillez noter que pour définir un client, vous devrez sélectionner un dataverse local déjà existant, lequel hébergera les ensembles de données moissonnés.
 
 harvestclients.noClients.how.tip2=Les notices récoltées peuvent être synchronisées avec le dépôt d'origine à l'aide de mises à jour incrémentielles programmées, par exemple, quotidiennes ou hebdomadaires. Alternativement, les moissonnages peuvent être exécutés à la demande, à partir de cette page ou via l'API REST.
-harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton « Ajouter un client » ci-dessus. Pour en savoir plus sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">moissonnage</a> du guide d'utilisation
+harvestclients.noClients.getStarted=Pour commencer, cliquez sur le bouton « Ajouter un client » ci-dessus. Pour en savoir davantage sur le moissonnage, consultez la section <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">moissonnage</a> du guide d'utilisation
 
 harvestclients.btn.add=Ajouter un client
 harvestclients.tab.header.name=Alias
@@ -360,7 +360,7 @@ harvestclients.newClientDialog.step1=Étape 1 de 4 - Renseignements au sujet du c
 harvestclients.newClientDialog.title.new=Définir un client de moissonnage
 harvestclients.newClientDialog.help=Configurer un client pour moissonner le contenu d'un serveur distant
 harvestclients.newClientDialog.nickname=Alias
-harvestclients.newClientDialog.nickname.helptext=Doit être composer de lettres, de chiffres, de traits de soulignement (_) et de tirets (-).
+harvestclients.newClientDialog.nickname.helptext=Doit être composé de lettres, de chiffres, de traits de soulignement (_) et de tirets (-).
 harvestclients.newClientDialog.nickname.required=L'alias du client ne peut pas être vide!
 harvestclients.newClientDialog.nickname.invalid=L'alias du client ne peut contenir que des lettres, des chiffres, des traits de soulignement (_), des tirets (-) , et ne peut excéder 30 caractères.
 harvestclients.newClientDialog.nickname.alreadyused=Cet alias est déjà utilisé.
@@ -440,13 +440,13 @@ harvestserver.service.enable.success=Le service OAI a bien été activé.
 
 harvestserver.noSets.why.header=Qu'est ce qu'un serveur de moissonnage?
 harvestserver.noSets.why.reason1=Le moissonnage consiste à échanger des métadonnées avec d'autres dépôts. En tant que  <b><i>serveur</i></b> de moissonnage, votre dataverse peut rendre disponible certains ensembles de données locaux à des clients de moissonnage distants. Il peut s'agir d'autres instances de Dataverse, ou encore de clients compatibles avec le protocole de moissonnage OAI-PMH.
-harvestserver.noSets.why.reason2=Seuls les ensembles de données publiés et non restreints de votre dataverse peuvent être moissonnés. Les clients distants maintiennent normalement leurs enregistrements synchronisés grâce à des mises à jour incrémentielles programmées, quotidiennes ou hebdomadaires, réduisant ainsi la charge sur votre serveur. Notez que seules les métadonnées sont moissonnées. Les moissonneurs distants ne tentent généralement pas de télécharger eux-mêmes les fichiers de données.
+harvestserver.noSets.why.reason2=Seuls les ensembles de données publiés et non restreints de votre Dataverse peuvent être moissonnés. Les clients distants maintiennent normalement leurs enregistrements synchronisés grâce à des mises à jour incrémentielles programmées, quotidiennes ou hebdomadaires, réduisant ainsi la charge sur votre serveur. Notez que seules les métadonnées sont moissonnées. Les moissonneurs distants ne tentent généralement pas de télécharger eux-mêmes les fichiers de données.
 
-harvestserver.noSets.how.header=Comment faire fonctionner un serveur de moissonnage?
-harvestserver.noSets.how.tip1=Le serveur de moissonnage peut être activé ou désactivé depuis cette page. 
-harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</ i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 - pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId: "doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
+harvestserver.noSets.how.header=Comment activer un serveur de moissonnage?
+harvestserver.noSets.how.tip1=Le serveur de moissonnage peut être activé ou désactivé à partir de cette page. 
+harvestserver.noSets.how.tip2=Une fois le service activé, vous pouvez définir des collections d'ensembles de données locaux qui seront disponibles pour les moissonneurs distants sous <i>Ensembles OAI</i>. Les ensembles sont définis par des requêtes de recherche (par exemple, authorName:king; ou parentId:1234 - pour sélectionner tous les ensembles de données appartenant au dataverse spécifié; ou dsPersistentId: "doi:1234/" pour sélectionner tous les ensembles de données avec l'identifiant perenne spécifié). Consultez la section sur l'API de recherche du guide d'utilisation de Dataverse pour plus d'informations sur les requêtes de recherche.  
 
-harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton « Ajouter un ensemble ». Pour en savoir plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">moissonnage</a> du guide d'utilisation.
+harvestserver.noSets.getStarted=Pour commencer, activez le serveur OAI et cliquez sur le bouton « Ajouter un ensemble (set) ». Pour en savoir plus sur le moissonnage, consultez la section  <a href="{0}/{1}/user/index.html#index" title="Harvesting - Dataverse User Guide" target="_blank">moissonnage</a> du guide d'utilisation.
 
 harvestserver.btn.add=Ajouter un ensemble (set)
 harvestserver.tab.header.spec=setSpec OAI (identifiant OAI de l'ensemble)

--- a/src/main/java/ValidationMessages.properties
+++ b/src/main/java/ValidationMessages.properties
@@ -7,5 +7,5 @@ user.usernameLenght=Username must be between 2 and 60 characters.
 user.ilegalCharacters=Found an illegal character(s). Valid characters are a-Z, 0-9, '_', '-', and '.'."
 user.invalidEmail=Please enter a valid email address.
 user.firstName=Please enter your first name.
-=Please enter your last name.
+user.lastName=Please enter your last name.
 user.affiliation=Please enter your affiliation.

--- a/src/main/java/ValidationMessages_fr.properties
+++ b/src/main/java/ValidationMessages_fr.properties
@@ -8,3 +8,4 @@ user.ilegalCharacters=Caractères non valides utilisés. Les caractères valides so
 user.invalidEmail=Veuillez entrer une adresse courriel valide.
 user.firstName=Veuillez entrer votre prénom.
 user.lastName=Veuillez entrer votre nom de famille.
+user.affiliation=Veuillez entrer votre affiliation institutionnelle.


### PR DESCRIPTION
Bundle_fr.properties

- new variables translated in French
- a few corrections to already existing variables were made
(standardization of non-breaking spaces before colon, standardization of
ellipsis, review of téléverser vs télécharger, etc.)

Bundle.properties (en)

- standardization of ellipsis
- "encounted" corrected for "encountered"

*** Note that variables starting from line 1943 to 1965 in the French
file DO NOT HAVE equivalent in the English file. Are those define
elsewhere (database?)....

ValidationMessages_fr: one variable added (affiliation)

ValidationMessages.properties (en): one variable corrected (name of the
variable "user.lastname" seems to be missing).

--------------------------------------------------------

JIRA issues related: DAT-76, DAT-88, DAT-81, DAT-86(?), DAT-77 (?), DAT-97(?), DAT-103(?), others?